### PR TITLE
feat: today/yesterday featured posts module on category pages

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -81,6 +81,7 @@ const config: Config = {
   testEnvironment: 'jsdom',
   moduleNameMapper: {
     '^.+\\.module\\.(css|sass|scss)$': 'identity-obj-proxy',
+    '^@app/(.*)$': '<rootDir>/src/app/$1',
     '^@components/(.*)$': '<rootDir>/src/components/$1',
     '^@blocks/(.*)$': '<rootDir>/src/blocks/$1',
     '^@lib/(.*)$': '<rootDir>/src/lib/$1',

--- a/src/app/(category)/categoria/[...slug]/page.tsx
+++ b/src/app/(category)/categoria/[...slug]/page.tsx
@@ -1,15 +1,24 @@
 export const dynamic = 'force-static'
 
-import { MENU, MENU_B, CATEGORY_PATH } from '@lib/constants'
+import { MENU, MENU_B, MAIN_MENU, CATEGORY_PATH } from '@lib/constants'
 import { Content } from '@blocks/content/CategoryPosts'
 import { Container } from '@components/Container'
 import { PageTitle } from '@components/PageTitle'
 import { Sidebar } from '@components/Sidebar'
+import {
+  TodayHeroSection,
+  TodaySecondaryGrid
+} from '@blocks/content/TodayYesterdayModule'
+import { getTodayYesterdayPosts } from '@app/actions/getTodayYesterdayPosts'
 import { sharedOpenGraph } from '@lib/sharedOpenGraph'
 import { categoryName, titleFromSlug } from '@lib/utils'
 import { getStaticSlugs } from '@lib/utils/getStaticSlugs'
 import { Suspense } from 'react'
 import { Loading } from '@components/LoadingCategory'
+
+const SLUGS_WITH_TODAY_MODULE = new Set(
+  MAIN_MENU.map(item => item.href.split('/').pop()).filter(Boolean)
+)
 
 type Params = { slug: string[] }
 type SearchParams = { [key: string]: string | string[] | undefined }
@@ -49,6 +58,23 @@ export default async function Page(props: {
     ? params.slug[params.slug.length - 1]
     : params.slug
 
+  const hasTodayModule = SLUGS_WITH_TODAY_MODULE.has(slug)
+  const todayPosts = hasTodayModule
+    ? await getTodayYesterdayPosts({ slug })
+    : null
+
+  const shownCount = todayPosts?.edges.length ?? 0
+
+  // Mirror the rounding logic in TodayYesterdayModule so we only exclude posts actually rendered.
+  // Secondary grid: rounded down to nearest multiple of 3, capped at 6.
+  const secondaryCount =
+    shownCount >= 3 ? Math.floor(Math.min(shownCount - 1, 6) / 3) * 3 : 0
+  // Total rendered in module: hero (1) + secondary cards
+  const renderedCount = shownCount >= 1 ? 1 + secondaryCount : 0
+
+  const excludeIds =
+    todayPosts?.edges.slice(0, renderedCount).map(e => e.node.id) ?? []
+
   return (
     <>
       <PageTitle text={titleFromSlug(slug)} />
@@ -64,10 +90,12 @@ export default async function Page(props: {
           <AdSenseBanner className={'min-h-[70px]'} {...ad.global.top_header} />
         </div>
       </div> */}
+      {shownCount >= 1 && <TodayHeroSection posts={todayPosts!} />}
       <Container className='py-10' sidebar>
         <section className='w-full md:w-2/3 md:pr-8 lg:w-3/4'>
+          {shownCount >= 1 && <TodaySecondaryGrid posts={todayPosts!} />}
           <Suspense fallback={<Loading />}>
-            <Content slug={slug} />
+            <Content slug={slug} excludeIds={excludeIds} />
           </Suspense>
         </section>
         <Sidebar />

--- a/src/app/actions/getTodayYesterdayPosts/__tests__/getTodayYesterdayPosts.test.ts
+++ b/src/app/actions/getTodayYesterdayPosts/__tests__/getTodayYesterdayPosts.test.ts
@@ -1,0 +1,63 @@
+import { getTodayYesterdayPosts } from '..'
+
+jest.mock('@app/actions/fetchAPI', () => ({
+  cachedFetchAPI: jest.fn()
+}))
+
+import { cachedFetchAPI } from '@app/actions/fetchAPI'
+
+const mockFetch = cachedFetchAPI as jest.Mock
+
+const makeEdge = (daysAgo: number) => {
+  const d = new Date()
+  d.setDate(d.getDate() - daysAgo)
+  return {
+    node: {
+      id: `id-${daysAgo}`,
+      title: `Post ${daysAgo}`,
+      uri: `/post-${daysAgo}`,
+      date: d.toISOString(),
+      categories: { edges: [] }
+    }
+  }
+}
+
+describe('getTodayYesterdayPosts', () => {
+  beforeEach(() => jest.clearAllMocks())
+
+  test('returns null when API returns no data', async () => {
+    mockFetch.mockResolvedValue(null)
+    const result = await getTodayYesterdayPosts({ slug: 'nacionales' })
+    expect(result).toBeNull()
+  })
+
+  test('returns null when posts field is missing', async () => {
+    mockFetch.mockResolvedValue({})
+    const result = await getTodayYesterdayPosts({ slug: 'nacionales' })
+    expect(result).toBeNull()
+  })
+
+  test('filters out posts older than 3 days', async () => {
+    const recent = makeEdge(1)
+    const old = makeEdge(5)
+    mockFetch.mockResolvedValue({ posts: { edges: [recent, old] } })
+    const result = await getTodayYesterdayPosts({ slug: 'nacionales' })
+    expect(result?.edges).toHaveLength(1)
+    expect(result?.edges[0]?.node.id).toBe('id-1')
+  })
+
+  test('includes posts from today and within 3 days', async () => {
+    const edges = [makeEdge(0), makeEdge(1), makeEdge(2), makeEdge(3)]
+    mockFetch.mockResolvedValue({ posts: { edges } })
+    const result = await getTodayYesterdayPosts({ slug: 'nacionales' })
+    expect(result?.edges.length).toBeGreaterThanOrEqual(3)
+  })
+
+  test('returns empty edges array when all posts are too old', async () => {
+    mockFetch.mockResolvedValue({
+      posts: { edges: [makeEdge(10), makeEdge(7)] }
+    })
+    const result = await getTodayYesterdayPosts({ slug: 'nacionales' })
+    expect(result?.edges).toHaveLength(0)
+  })
+})

--- a/src/app/actions/getTodayYesterdayPosts/index.ts
+++ b/src/app/actions/getTodayYesterdayPosts/index.ts
@@ -41,14 +41,19 @@ export interface TodayPostsResult {
   edges: { node: TodayPost }[]
 }
 
-function getThreeDaysAgoDateStringInCaracas(): string {
-  // America/Caracas is UTC-4 (no DST)
-  const now = new Date()
-  const caracasMs = now.getTime() - (now.getTimezoneOffset() + 240) * 60000
-  const caracasNow = new Date(caracasMs)
-  const threeDaysAgo = new Date(caracasNow)
-  threeDaysAgo.setDate(threeDaysAgo.getDate() - 3)
-  return threeDaysAgo.toISOString().split('T')[0] ?? '' // "YYYY-MM-DD"
+function getRecentCutoffDateInCaracas(): string {
+  // America/Caracas is UTC-4 (no DST).
+  // Use 3 days as the cutoff so slow news days (e.g. weekends) don't produce
+  // an empty module. Posts older than 3 days are excluded by the filter below.
+  const cutoff = new Date()
+  cutoff.setUTCDate(cutoff.getUTCDate() - 3)
+  // Format in Caracas time directly, independent of host timezone.
+  return new Intl.DateTimeFormat('en-CA', {
+    timeZone: 'America/Caracas',
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit'
+  }).format(cutoff) // "YYYY-MM-DD"
 }
 
 export async function getTodayYesterdayPosts({
@@ -56,7 +61,7 @@ export async function getTodayYesterdayPosts({
 }: {
   slug: string
 }): Promise<TodayPostsResult | null> {
-  const yesterdayDate = getThreeDaysAgoDateStringInCaracas()
+  const recentCutoff = getRecentCutoffDateInCaracas()
 
   const data = await cachedFetchAPI<{ posts: TodayPostsResult }>({
     query: queryTodayYesterdayPosts,
@@ -66,10 +71,10 @@ export async function getTodayYesterdayPosts({
 
   if (!data?.posts) return null
 
-  // Filter to only posts from today or yesterday (Caracas time)
+  // Filter to only posts within the recent cutoff window (Caracas time)
   const filteredEdges = data.posts.edges.filter(({ node }) => {
     const postDate = node.date.split('T')[0]
-    return postDate !== undefined && postDate >= yesterdayDate
+    return postDate !== undefined && postDate >= recentCutoff
   })
 
   return { edges: filteredEdges }

--- a/src/app/actions/getTodayYesterdayPosts/index.ts
+++ b/src/app/actions/getTodayYesterdayPosts/index.ts
@@ -1,0 +1,76 @@
+'use server'
+
+import { cachedFetchAPI } from '@app/actions/fetchAPI'
+import { TIME_REVALIDATE } from '@lib/constants'
+import { queryTodayYesterdayPosts } from './query'
+
+export interface TodayPost {
+  id: string
+  title: string
+  uri: string
+  date: string
+  excerpt?: string
+  featuredImage?: {
+    node: {
+      sourceUrl: string
+      srcSet?: string
+      mediaDetails?: {
+        width: number
+        height: number
+      }
+    }
+  }
+  categories: {
+    edges: {
+      node: {
+        name: string
+        slug: string
+        parentId?: string | null
+      }
+    }[]
+    type: string
+    className?: string
+    slice?: number
+  }
+  customFields?: {
+    videodestacado?: string
+  }
+}
+
+export interface TodayPostsResult {
+  edges: { node: TodayPost }[]
+}
+
+function getThreeDaysAgoDateStringInCaracas(): string {
+  // America/Caracas is UTC-4 (no DST)
+  const now = new Date()
+  const caracasMs = now.getTime() - (now.getTimezoneOffset() + 240) * 60000
+  const caracasNow = new Date(caracasMs)
+  const threeDaysAgo = new Date(caracasNow)
+  threeDaysAgo.setDate(threeDaysAgo.getDate() - 3)
+  return threeDaysAgo.toISOString().split('T')[0] ?? '' // "YYYY-MM-DD"
+}
+
+export async function getTodayYesterdayPosts({
+  slug
+}: {
+  slug: string
+}): Promise<TodayPostsResult | null> {
+  const yesterdayDate = getThreeDaysAgoDateStringInCaracas()
+
+  const data = await cachedFetchAPI<{ posts: TodayPostsResult }>({
+    query: queryTodayYesterdayPosts,
+    variables: { slug },
+    revalidate: TIME_REVALIDATE.HOUR
+  })
+
+  if (!data?.posts) return null
+
+  // Filter to only posts from today or yesterday (Caracas time)
+  const filteredEdges = data.posts.edges.filter(({ node }) => {
+    const postDate = node.date.split('T')[0]
+    return postDate !== undefined && postDate >= yesterdayDate
+  })
+
+  return { edges: filteredEdges }
+}

--- a/src/app/actions/getTodayYesterdayPosts/query.ts
+++ b/src/app/actions/getTodayYesterdayPosts/query.ts
@@ -1,0 +1,46 @@
+import { IMAGE_SIZES } from '@lib/constants'
+
+export const queryTodayYesterdayPosts = `
+query TodayYesterdayPosts($slug: String!) {
+  posts(
+    first: 7
+    where: {
+      orderby: { field: DATE, order: DESC }
+      categoryName: $slug
+      status: PUBLISH
+    }
+  ) {
+    edges {
+      node {
+        id
+        title
+        uri
+        date
+        excerpt
+        featuredImage {
+          node {
+            sourceUrl(size: ${IMAGE_SIZES.LARGE})
+            srcSet
+            mediaDetails {
+              width
+              height
+            }
+          }
+        }
+        categories {
+          edges {
+            node {
+              name
+              slug
+              parentId
+            }
+          }
+        }
+        customFields {
+          videodestacado
+        }
+      }
+    }
+  }
+}
+`

--- a/src/blocks/content/CategoryPosts/index.tsx
+++ b/src/blocks/content/CategoryPosts/index.tsx
@@ -7,6 +7,7 @@ import { AdSenseBanner } from '@components/AdSenseBanner'
 import { CategoryArticle } from '@components/CategoryArticle'
 import { Loading } from '@components/LoadingCategory'
 import { Newsletter } from '@components/Newsletter'
+import { NcolAdSlot } from '@components/NcolAdSlot'
 import { ad } from '@lib/ads'
 import { useCategoryPosts } from '@lib/hooks/data/useCategoryPosts'
 import { NotFoundAlert } from '@components/NotFoundAlert'
@@ -14,13 +15,20 @@ import { LoaderCategoryPosts } from '@components/LoaderCategoryPosts'
 
 const postsQty = Number(process.env.NEXT_PUBLIC_POSTS_QTY_CATEGORY ?? 10)
 
-export const Content = ({ slug }: { slug: string }) => {
+export const Content = ({
+  slug,
+  excludeIds = []
+}: {
+  slug: string
+  excludeIds?: string[]
+}) => {
+  const fetchQty = postsQty + excludeIds.length
   const {
     data: result,
     error,
     isLoading,
     fetchMorePosts
-  } = useCategoryPosts({ slug, qty: postsQty, offset: 0 })
+  } = useCategoryPosts({ slug, qty: fetchQty, offset: 0 })
 
   if (error) {
     Sentry.captureException(error, {
@@ -38,10 +46,21 @@ export const Content = ({ slug }: { slug: string }) => {
     return <NotFoundAlert />
   }
 
-  const { edges } = result ?? { edges: [] }
+  const allEdges = result?.edges ?? []
+  const excludeSet = new Set(excludeIds)
+  const edges =
+    excludeSet.size > 0
+      ? allEdges.filter(({ node }) => !excludeSet.has(node.id ?? ''))
+      : allEdges
 
   return (
     <>
+      {excludeIds.length > 0 && (
+        <>
+          <NcolAdSlot slot='article-top' className='my-4 flex justify-center' />
+        </>
+      )}
+      <hr className='mb-6' />
       {edges.map(({ node }, index) => (
         <Fragment key={node.id}>
           <CategoryArticle
@@ -65,6 +84,7 @@ export const Content = ({ slug }: { slug: string }) => {
         <LoaderCategoryPosts
           slug={slug}
           qty={postsQty}
+          initialOffset={fetchQty}
           fetchMorePosts={fetchMorePosts}
         />
       )}

--- a/src/blocks/content/TodayYesterdayModule/__tests__/TodayYesterdayModule.test.tsx
+++ b/src/blocks/content/TodayYesterdayModule/__tests__/TodayYesterdayModule.test.tsx
@@ -1,0 +1,80 @@
+import { render, screen } from '@testing-library/react'
+import { getSecondaryPosts, TodayHeroSection, TodaySecondaryGrid } from '..'
+import { TodayPostsResult } from '@app/actions/getTodayYesterdayPosts'
+
+jest.mock('@components/TodayHeroPost', () => ({
+  TodayHeroPost: ({ title }: any) => <div data-testid='hero'>{title}</div>
+}))
+jest.mock('@components/TodayNewsCard', () => ({
+  TodayNewsCard: ({ title }: any) => <div data-testid='card'>{title}</div>
+}))
+
+const makePost = (id: string) => ({
+  node: {
+    id,
+    title: `Post ${id}`,
+    uri: `/post-${id}`,
+    date: '2026-04-23T10:00:00',
+    categories: { edges: [] }
+  }
+})
+
+const makePosts = (count: number): TodayPostsResult => ({
+  edges: Array.from({ length: count }, (_, i) => makePost(String(i + 1)))
+})
+
+describe('getSecondaryPosts', () => {
+  test('returns empty array when fewer than 3 posts', () => {
+    expect(getSecondaryPosts(makePosts(2).edges)).toEqual([])
+  })
+
+  test('returns 3 posts when 4 total (rounds down to multiple of 3)', () => {
+    expect(getSecondaryPosts(makePosts(4).edges)).toHaveLength(3)
+  })
+
+  test('returns 3 posts when exactly 4 total', () => {
+    expect(getSecondaryPosts(makePosts(4).edges)).toHaveLength(3)
+  })
+
+  test('returns 6 posts when 7 total (hero + 6 secondary)', () => {
+    expect(getSecondaryPosts(makePosts(7).edges)).toHaveLength(6)
+  })
+
+  test('caps at 6 secondary posts even with more input', () => {
+    expect(getSecondaryPosts(makePosts(20).edges)).toHaveLength(6)
+  })
+
+  test('returns 3 when exactly 3 total (hero + 2 = 2 secondary, rounds to 0? no: 3 total → 2 secondary → rounds to 0)', () => {
+    // 3 total: hero=1, remaining=2, capped=2, rounded=floor(2/3)*3=0
+    expect(getSecondaryPosts(makePosts(3).edges)).toHaveLength(0)
+  })
+
+  test('returns 3 when 4 posts', () => {
+    // 4 total: hero=1, remaining=3, capped=3, rounded=3
+    expect(getSecondaryPosts(makePosts(4).edges)).toHaveLength(3)
+  })
+})
+
+describe('TodayHeroSection', () => {
+  test('renders nothing when no posts', () => {
+    const { container } = render(<TodayHeroSection posts={{ edges: [] }} />)
+    expect(container.firstChild).toBeNull()
+  })
+
+  test('renders hero post', () => {
+    render(<TodayHeroSection posts={makePosts(1)} />)
+    expect(screen.getByTestId('hero')).toBeInTheDocument()
+  })
+})
+
+describe('TodaySecondaryGrid', () => {
+  test('renders nothing when fewer than 3 posts', () => {
+    const { container } = render(<TodaySecondaryGrid posts={makePosts(2)} />)
+    expect(container.firstChild).toBeNull()
+  })
+
+  test('renders cards for secondary posts', () => {
+    render(<TodaySecondaryGrid posts={makePosts(7)} />)
+    expect(screen.getAllByTestId('card')).toHaveLength(6)
+  })
+})

--- a/src/blocks/content/TodayYesterdayModule/index.tsx
+++ b/src/blocks/content/TodayYesterdayModule/index.tsx
@@ -1,0 +1,51 @@
+import {
+  TodayPost,
+  TodayPostsResult
+} from '@app/actions/getTodayYesterdayPosts'
+import { TodayHeroPost } from '@components/TodayHeroPost'
+import { TodayNewsCard } from '@components/TodayNewsCard'
+
+interface Props {
+  posts: TodayPostsResult
+}
+
+export function getSecondaryPosts(
+  edges: TodayPostsResult['edges']
+): TodayPost[] {
+  if (edges.length < 3) return []
+  const raw = edges.slice(1).map(({ node }) => node)
+  const capped = Math.min(raw.length, 6)
+  const rounded = Math.floor(capped / 3) * 3
+  return raw.slice(0, rounded)
+}
+
+// Full-width hero — rendered outside the sidebar Container
+const TodayHeroSection = ({ posts }: Props) => {
+  const heroPost = posts.edges[0]?.node
+  if (!heroPost) return null
+
+  return (
+    <div className='container mx-auto px-6 pt-0 sm:px-7 sm:pt-6'>
+      <TodayHeroPost {...heroPost} />
+    </div>
+  )
+}
+
+// Secondary cards grid — rendered inside the sidebar column
+const TodaySecondaryGrid = ({ posts }: Props) => {
+  const secondaryPosts = getSecondaryPosts(posts.edges)
+  if (secondaryPosts.length === 0) return null
+
+  return (
+    <section className='mb-8'>
+      <hr className='mb-4 border-slate-200 dark:border-neutral-600' />
+      <div className='grid grid-cols-2 gap-4 md:grid-cols-3'>
+        {secondaryPosts.map(post => (
+          <TodayNewsCard key={post.id} {...post} />
+        ))}
+      </div>
+    </section>
+  )
+}
+
+export { TodayHeroSection, TodaySecondaryGrid }

--- a/src/blocks/content/TodayYesterdayModule/index.tsx
+++ b/src/blocks/content/TodayYesterdayModule/index.tsx
@@ -15,6 +15,7 @@ export function getSecondaryPosts(
   if (edges.length < 3) return []
   const raw = edges.slice(1).map(({ node }) => node)
   const capped = Math.min(raw.length, 6)
+  // Round down to nearest multiple of 3 so the grid never has an orphan card.
   const rounded = Math.floor(capped / 3) * 3
   return raw.slice(0, rounded)
 }

--- a/src/blocks/content/TodayYesterdayModule/index.tsx
+++ b/src/blocks/content/TodayYesterdayModule/index.tsx
@@ -36,10 +36,15 @@ const TodaySecondaryGrid = ({ posts }: Props) => {
   const secondaryPosts = getSecondaryPosts(posts.edges)
   if (secondaryPosts.length === 0) return null
 
+  const mobileColClass =
+    secondaryPosts.length === 3
+      ? 'grid-cols-1 sm:grid-cols-3'
+      : 'grid-cols-2 md:grid-cols-3'
+
   return (
     <section className='mb-8'>
       <hr className='mb-4 border-slate-200 dark:border-neutral-600' />
-      <div className='grid grid-cols-2 gap-4 md:grid-cols-3'>
+      <div className={`grid gap-4 ${mobileColClass}`}>
         {secondaryPosts.map(post => (
           <TodayNewsCard key={post.id} {...post} />
         ))}

--- a/src/components/CategoryArticle/index.tsx
+++ b/src/components/CategoryArticle/index.tsx
@@ -51,6 +51,25 @@ const CategoryArticle = ({
 
   return (
     <article key={id} className={classes}>
+      {featuredImage && typeIs(LIST) && (
+        <div className={classesImage}>
+          <div style={{ width: '100%', height: '100%', position: 'relative' }}>
+            <LazyImage
+              uri={uri}
+              title={limitedTitle}
+              coverImage={featuredImage?.node.sourceUrl}
+              srcSet={featuredImage?.node.sourceUrl}
+              className={classesCoverImage}
+              size={imageSize}
+            />
+            {customFields?.videodestacado && (
+              <span className='bg-secondary pointer-events-none absolute top-1 right-1 z-20 rounded p-1 px-1.5 py-0.5 font-sans text-[10px] font-bold tracking-wide text-white uppercase shadow'>
+                + Video
+              </span>
+            )}
+          </div>
+        </div>
+      )}
       <div className={classesContentWrapper}>
         {categories && (typeIs(THUMBNAIL) || typeIs(LIST)) && (
           <div className={`${!typeIs(THUMBNAIL) && 'mb-1'}`}>
@@ -88,7 +107,7 @@ const CategoryArticle = ({
           </div>
         )}
       </div>
-      {featuredImage && (
+      {featuredImage && !typeIs(LIST) && (
         <div className={classesImage}>
           {categories &&
             (typeIs(SECONDARY) || typeIs(SIDEBAR) || typeIs(RECENT_NEWS)) && (

--- a/src/components/CategoryArticle/styles.ts
+++ b/src/components/CategoryArticle/styles.ts
@@ -73,10 +73,8 @@ export const getImageClasses = ({ type }: { type: string }) =>
 export const getTitleClasses = ({ type }: { type: string }) =>
   cn(
     {
-      'mb-3 font-sans text-lg leading-7 font-bold sm:text-xl': typeIs(
-        type,
-        LIST
-      )
+      'mb-3 font-sans text-lg leading-snug font-bold sm:text-xl sm:leading-7':
+        typeIs(type, LIST)
     },
     {
       'text-basemt-2 mb-3 font-sans leading-6 font-bold sm:leading-7 md:mb-2 md:text-lg':

--- a/src/components/CategoryArticle/styles.ts
+++ b/src/components/CategoryArticle/styles.ts
@@ -46,7 +46,7 @@ export const getCategoryArticleClasses = ({
 export const getImageClasses = ({ type }: { type: string }) =>
   cn(
     {
-      'mt-8 ml-3 h-16 w-20 sm:mt-0 sm:ml-5 sm:h-28 sm:w-40 lg:h-32 lg:w-48':
+      'mt-9 mr-3 h-16 w-20 sm:mt-2 sm:mr-5 sm:h-28 sm:w-40 lg:h-32 lg:w-48':
         typeIs(type, LIST)
     },
     {

--- a/src/components/LoaderCategoryPosts/index.tsx
+++ b/src/components/LoaderCategoryPosts/index.tsx
@@ -7,8 +7,13 @@ import { useState } from 'react'
 import { GAEvent } from '@lib/utils'
 import * as Sentry from '@sentry/nextjs'
 
-const LoaderCategoryPosts = ({ slug, qty, fetchMorePosts }: LoaderProps) => {
-  const [offset, setOffset] = useState(qty)
+const LoaderCategoryPosts = ({
+  slug,
+  qty,
+  initialOffset,
+  fetchMorePosts
+}: LoaderProps) => {
+  const [offset, setOffset] = useState(initialOffset ?? qty)
   const [status, setStatus] = useState<string>(STATUS.Success)
 
   const handleLoadMore = async () => {

--- a/src/components/TodayCategoryLabel/index.tsx
+++ b/src/components/TodayCategoryLabel/index.tsx
@@ -1,0 +1,26 @@
+import { TodayPost } from '@app/actions/getTodayYesterdayPosts'
+import { getPostCategoriesClasses } from '@components/PostCategories/styles'
+import { processCategories } from '@lib/utils/processCategories'
+import { CATEGORY_PATH } from '@lib/constants'
+import Link from 'next/link'
+
+const TodayCategoryLabel = ({
+  categories,
+  className
+}: {
+  categories: TodayPost['categories']
+  className?: string
+}) => {
+  const processed = processCategories(categories.edges, 1)
+  if (!processed.length) return null
+  const cat = processed[0]?.node
+  const classes = getPostCategoriesClasses(className)
+  if (!cat) return null
+  return (
+    <Link href={`${CATEGORY_PATH}/${cat.slug}`} className={classes}>
+      {cat.name}
+    </Link>
+  )
+}
+
+export { TodayCategoryLabel }

--- a/src/components/TodayHeroPost/__tests__/TodayHeroPost.test.tsx
+++ b/src/components/TodayHeroPost/__tests__/TodayHeroPost.test.tsx
@@ -1,0 +1,79 @@
+import { render, screen } from '@testing-library/react'
+import { TodayHeroPost } from '..'
+
+jest.mock('@components/HoverPrefetchLink', () => ({
+  HoverPrefetchLink: ({ children, href }: any) => <a href={href}>{children}</a>
+}))
+jest.mock('@components/DateTime', () => ({
+  DateTime: () => <time>date</time>
+}))
+jest.mock('@lib/utils/ga', () => ({ GAEvent: jest.fn() }))
+jest.mock('next/link', () => ({
+  __esModule: true,
+  default: ({ children, href }: any) => <a href={href}>{children}</a>
+}))
+
+const base = {
+  id: 'abc',
+  title: 'A long enough title for the hero post',
+  uri: '/post/abc',
+  date: '2026-04-23T10:00:00',
+  excerpt: '<p>Excerpt text</p>',
+  categories: {
+    edges: [
+      { node: { name: 'Nacionales', slug: 'nacionales', parentId: null } }
+    ]
+  },
+  featuredImage: {
+    node: {
+      sourceUrl: '/img.jpg',
+      srcSet: '/img.jpg 800w',
+      mediaDetails: { width: 800, height: 450 }
+    }
+  }
+}
+
+describe('TodayHeroPost', () => {
+  test('returns null when title is too short', () => {
+    const { container } = render(<TodayHeroPost {...base} title='short' />)
+    expect(container.firstChild).toBeNull()
+  })
+
+  test('renders smaller variant when image is narrow', () => {
+    const { container } = render(<TodayHeroPost {...base} />)
+    expect(container.querySelector('article')).toBeInTheDocument()
+    expect(screen.getByAltText(/a long enough/i)).toBeInTheDocument()
+    expect(screen.getByText(/nacionales/i)).toBeInTheDocument()
+  })
+
+  test('renders wide overlay variant when image width >= 1200', () => {
+    const wide = {
+      ...base,
+      featuredImage: {
+        node: {
+          ...base.featuredImage.node,
+          mediaDetails: { width: 1200, height: 600 }
+        }
+      }
+    }
+    render(<TodayHeroPost {...wide} />)
+    expect(screen.getByAltText(/a long enough/i)).toBeInTheDocument()
+    expect(screen.getByText(/nacionales/i)).toBeInTheDocument()
+  })
+
+  test('renders without featuredImage', () => {
+    const { container } = render(
+      <TodayHeroPost {...base} featuredImage={undefined} />
+    )
+    expect(container.querySelector('article')).toBeInTheDocument()
+  })
+
+  test('both images use fetchPriority high and eager loading', () => {
+    const { getAllByRole } = render(<TodayHeroPost {...base} />)
+    const imgs = getAllByRole('img')
+    imgs.forEach(img => {
+      expect(img).toHaveAttribute('fetchpriority', 'high')
+      expect(img).toHaveAttribute('loading', 'eager')
+    })
+  })
+})

--- a/src/components/TodayHeroPost/index.tsx
+++ b/src/components/TodayHeroPost/index.tsx
@@ -1,0 +1,195 @@
+'use client'
+
+import { TodayPost } from '@app/actions/getTodayYesterdayPosts'
+import { DateTime } from '@components/DateTime'
+import { HoverPrefetchLink } from '@components/HoverPrefetchLink'
+import { getPostCategoriesClasses } from '@components/PostCategories/styles'
+import { processCategories } from '@lib/utils/processCategories'
+import { GAEvent } from '@lib/utils/ga'
+import { GA_EVENTS, CATEGORY_PATH } from '@lib/constants'
+import { limitStringCharacters } from '@lib/utils/limitStringCharacters'
+import Link from 'next/link'
+
+const WIDE_IMAGE_THRESHOLD = 1200
+
+const CategoryLabel = ({
+  categories,
+  className
+}: {
+  categories: TodayPost['categories']
+  className?: string
+}) => {
+  const processed = processCategories(categories.edges, 1)
+  if (!processed.length) return null
+  const cat = processed[0]?.node
+  const classes = getPostCategoriesClasses(className)
+  if (!cat) return null
+  return (
+    <Link href={`${CATEGORY_PATH}/${cat.slug}`} className={classes}>
+      {cat.name}
+    </Link>
+  )
+}
+
+const TodayHeroPost = ({
+  id,
+  title,
+  uri,
+  date,
+  excerpt,
+  featuredImage,
+  categories,
+  customFields
+}: TodayPost) => {
+  const limitedTitle = limitStringCharacters(title)
+  if (!limitedTitle || limitedTitle.length <= 10) return null
+
+  const imageWidth = featuredImage?.node?.mediaDetails?.width ?? 0
+  const isWide = imageWidth >= WIDE_IMAGE_THRESHOLD
+
+  // Wide image: full-width overlay, no horizontal padding (bleeds to container edges)
+  if (isWide) {
+    return (
+      <article
+        key={id}
+        className='relative -mx-6 mb-4 overflow-hidden sm:-mx-7 sm:rounded-sm'
+      >
+        <div
+          className='relative w-full overflow-hidden'
+          style={{ maxHeight: 500 }}
+        >
+          <HoverPrefetchLink
+            href={uri}
+            aria-label={limitedTitle}
+            onClick={() =>
+              GAEvent({
+                category: GA_EVENTS.POST_LINK.SINGLE.CATEGORY,
+                label: 'TODAY_HERO_OVERLAY'
+              })
+            }
+          >
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            <img
+              src={featuredImage?.node.sourceUrl ?? ''}
+              srcSet={featuredImage?.node.srcSet}
+              alt={limitedTitle}
+              className='w-full object-cover'
+              fetchPriority='high'
+              loading='eager'
+            />
+          </HoverPrefetchLink>
+          {customFields?.videodestacado && (
+            <span className='bg-secondary pointer-events-none absolute top-2 right-2 z-20 rounded px-1.5 py-0.5 font-sans text-[10px] font-bold tracking-wide text-white uppercase shadow'>
+              + Video
+            </span>
+          )}
+          <div
+            className='pointer-events-none absolute inset-0'
+            style={{
+              background:
+                'linear-gradient(to top, rgba(0,0,0,0.92) 0%, rgba(0,0,0,0.6) 40%, transparent 70%)'
+            }}
+          />
+          <div className='absolute right-0 bottom-0 left-0 p-4 md:p-6'>
+            {categories && (
+              <CategoryLabel
+                categories={categories}
+                className='mb-2 text-white/90'
+              />
+            )}
+            <h2 className='text-xl leading-snug font-bold text-white md:text-3xl'>
+              <HoverPrefetchLink
+                href={uri}
+                onClick={() =>
+                  GAEvent({
+                    category: GA_EVENTS.POST_LINK.SINGLE.CATEGORY,
+                    label: 'TODAY_HERO_OVERLAY'
+                  })
+                }
+              >
+                {limitedTitle}
+              </HoverPrefetchLink>
+            </h2>
+            {excerpt && (
+              <div
+                className='mt-2 line-clamp-2 text-sm text-white'
+                dangerouslySetInnerHTML={{ __html: excerpt }}
+              />
+            )}
+            <div className='mt-2 text-sm text-white'>
+              <DateTime dateString={date} />
+            </div>
+          </div>
+        </div>
+      </article>
+    )
+  }
+
+  // Smaller image: image left, text right
+  return (
+    <article key={id} className='mt-6 mb-4 flex flex-col gap-5 sm:flex-row'>
+      {featuredImage && (
+        <div className='relative w-full shrink-0 overflow-hidden sm:w-[55%]'>
+          <HoverPrefetchLink
+            href={uri}
+            aria-label={limitedTitle}
+            onClick={() =>
+              GAEvent({
+                category: GA_EVENTS.POST_LINK.SINGLE.CATEGORY,
+                label: 'TODAY_HERO'
+              })
+            }
+          >
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            <img
+              src={featuredImage.node.sourceUrl}
+              srcSet={featuredImage.node.srcSet}
+              alt={limitedTitle}
+              className='aspect-video w-full object-cover'
+              fetchPriority='high'
+              loading='eager'
+            />
+          </HoverPrefetchLink>
+          {customFields?.videodestacado && (
+            <span className='bg-secondary pointer-events-none absolute top-1 right-1 z-20 rounded px-1.5 py-0.5 font-sans text-[10px] font-bold tracking-wide text-white uppercase shadow'>
+              + Video
+            </span>
+          )}
+        </div>
+      )}
+      <div className='flex flex-col justify-center'>
+        {categories && (
+          <CategoryLabel
+            categories={categories}
+            className='text-primary mb-1 uppercase'
+          />
+        )}
+        <h2 className='text-xl leading-snug font-bold text-slate-900 md:text-2xl dark:text-white'>
+          <HoverPrefetchLink
+            href={uri}
+            aria-label={limitedTitle}
+            onClick={() =>
+              GAEvent({
+                category: GA_EVENTS.POST_LINK.SINGLE.CATEGORY,
+                label: 'TODAY_HERO'
+              })
+            }
+          >
+            {limitedTitle}
+          </HoverPrefetchLink>
+        </h2>
+        {excerpt && (
+          <div
+            className='mt-2 line-clamp-3 text-sm text-slate-600 dark:text-neutral-300'
+            dangerouslySetInnerHTML={{ __html: excerpt }}
+          />
+        )}
+        <div className='mt-2 text-sm text-slate-500 dark:text-neutral-400'>
+          <DateTime dateString={date} />
+        </div>
+      </div>
+    </article>
+  )
+}
+
+export { TodayHeroPost }

--- a/src/components/TodayHeroPost/index.tsx
+++ b/src/components/TodayHeroPost/index.tsx
@@ -3,36 +3,14 @@
 import { TodayPost } from '@app/actions/getTodayYesterdayPosts'
 import { DateTime } from '@components/DateTime'
 import { HoverPrefetchLink } from '@components/HoverPrefetchLink'
-import { getPostCategoriesClasses } from '@components/PostCategories/styles'
-import { processCategories } from '@lib/utils/processCategories'
+import { TodayCategoryLabel } from '@components/TodayCategoryLabel'
 import { GAEvent } from '@lib/utils/ga'
-import { GA_EVENTS, CATEGORY_PATH } from '@lib/constants'
+import { GA_EVENTS } from '@lib/constants'
 import { limitStringCharacters } from '@lib/utils/limitStringCharacters'
-import Link from 'next/link'
 
 const WIDE_IMAGE_THRESHOLD = 1200
 
-const CategoryLabel = ({
-  categories,
-  className
-}: {
-  categories: TodayPost['categories']
-  className?: string
-}) => {
-  const processed = processCategories(categories.edges, 1)
-  if (!processed.length) return null
-  const cat = processed[0]?.node
-  const classes = getPostCategoriesClasses(className)
-  if (!cat) return null
-  return (
-    <Link href={`${CATEGORY_PATH}/${cat.slug}`} className={classes}>
-      {cat.name}
-    </Link>
-  )
-}
-
 const TodayHeroPost = ({
-  id,
   title,
   uri,
   date,
@@ -50,10 +28,7 @@ const TodayHeroPost = ({
   // Wide image: full-width overlay, no horizontal padding (bleeds to container edges)
   if (isWide) {
     return (
-      <article
-        key={id}
-        className='relative -mx-6 mb-4 overflow-hidden sm:-mx-7 sm:rounded-sm'
-      >
+      <article className='relative -mx-6 mb-4 overflow-hidden sm:-mx-7 sm:mx-0 sm:rounded-sm'>
         <div
           className='relative w-full overflow-hidden'
           style={{ maxHeight: 500 }}
@@ -92,7 +67,7 @@ const TodayHeroPost = ({
           />
           <div className='absolute right-0 bottom-0 left-0 p-4 md:p-6'>
             {categories && (
-              <CategoryLabel
+              <TodayCategoryLabel
                 categories={categories}
                 className='mb-2 text-white/90'
               />
@@ -127,7 +102,7 @@ const TodayHeroPost = ({
 
   // Smaller image: image left, text right
   return (
-    <article key={id} className='mt-6 mb-4 flex flex-col gap-5 sm:flex-row'>
+    <article className='mt-6 mb-4 flex flex-col gap-5 sm:flex-row'>
       {featuredImage && (
         <div className='relative w-full shrink-0 overflow-hidden sm:w-[55%]'>
           <HoverPrefetchLink
@@ -159,7 +134,7 @@ const TodayHeroPost = ({
       )}
       <div className='flex flex-col justify-center'>
         {categories && (
-          <CategoryLabel
+          <TodayCategoryLabel
             categories={categories}
             className='text-primary mb-1 uppercase'
           />

--- a/src/components/TodayHeroPost/index.tsx
+++ b/src/components/TodayHeroPost/index.tsx
@@ -112,7 +112,7 @@ const TodayHeroPost = ({
             </h2>
             {excerpt && (
               <div
-                className='mt-2 line-clamp-2 text-sm text-white'
+                className='mt-2 line-clamp-2 hidden text-sm text-white sm:block'
                 dangerouslySetInnerHTML={{ __html: excerpt }}
               />
             )}

--- a/src/components/TodayNewsCard/__tests__/TodayNewsCard.test.tsx
+++ b/src/components/TodayNewsCard/__tests__/TodayNewsCard.test.tsx
@@ -1,0 +1,68 @@
+import { render, screen } from '@testing-library/react'
+import { TodayNewsCard } from '..'
+
+jest.mock('@components/HoverPrefetchLink', () => ({
+  HoverPrefetchLink: ({ children, href }: any) => <a href={href}>{children}</a>
+}))
+jest.mock('@components/DateTime', () => ({
+  DateTime: () => <time>date</time>
+}))
+jest.mock('@lib/utils/ga', () => ({ GAEvent: jest.fn() }))
+jest.mock('next/link', () => ({
+  __esModule: true,
+  default: ({ children, href }: any) => <a href={href}>{children}</a>
+}))
+
+const base = {
+  id: 'card-1',
+  title: 'A long enough card title to render',
+  uri: '/post/card-1',
+  date: '2026-04-23T10:00:00',
+  categories: {
+    edges: [{ node: { name: 'Deportes', slug: 'deportes', parentId: null } }]
+  },
+  featuredImage: {
+    node: {
+      sourceUrl: '/card.jpg',
+      srcSet: '/card.jpg 400w',
+      mediaDetails: { width: 400, height: 225 }
+    }
+  }
+}
+
+describe('TodayNewsCard', () => {
+  test('returns null when title is too short', () => {
+    const { container } = render(<TodayNewsCard {...base} title='short' />)
+    expect(container.firstChild).toBeNull()
+  })
+
+  test('renders image, category link, title and date', () => {
+    render(<TodayNewsCard {...base} />)
+    expect(screen.getByAltText(/a long enough card/i)).toBeInTheDocument()
+    expect(screen.getByText(/deportes/i)).toBeInTheDocument()
+    expect(screen.getByText(/a long enough card/i)).toBeInTheDocument()
+    expect(screen.getByText('date')).toBeInTheDocument()
+  })
+
+  test('category label links to category page', () => {
+    render(<TodayNewsCard {...base} />)
+    const link = screen.getByRole('link', { name: /deportes/i })
+    expect(link).toHaveAttribute('href', '/categoria/deportes')
+  })
+
+  test('renders without featuredImage', () => {
+    const { container } = render(
+      <TodayNewsCard {...base} featuredImage={undefined} />
+    )
+    expect(container.querySelector('article')).toBeInTheDocument()
+    expect(container.querySelector('img')).toBeNull()
+  })
+
+  test('image uses lazy loading', () => {
+    render(<TodayNewsCard {...base} />)
+    expect(screen.getByAltText(/a long enough card/i)).toHaveAttribute(
+      'loading',
+      'lazy'
+    )
+  })
+})

--- a/src/components/TodayNewsCard/index.tsx
+++ b/src/components/TodayNewsCard/index.tsx
@@ -1,0 +1,103 @@
+'use client'
+
+import { TodayPost } from '@app/actions/getTodayYesterdayPosts'
+import { DateTime } from '@components/DateTime'
+import { HoverPrefetchLink } from '@components/HoverPrefetchLink'
+import { getPostCategoriesClasses } from '@components/PostCategories/styles'
+import { processCategories } from '@lib/utils/processCategories'
+import { GAEvent } from '@lib/utils/ga'
+import { GA_EVENTS, CATEGORY_PATH } from '@lib/constants'
+import { limitStringCharacters } from '@lib/utils/limitStringCharacters'
+import Link from 'next/link'
+
+const CategoryLabel = ({
+  categories,
+  className
+}: {
+  categories: TodayPost['categories']
+  className?: string
+}) => {
+  const processed = processCategories(categories.edges, 1)
+  if (!processed.length) return null
+  const cat = processed[0]?.node
+  const classes = getPostCategoriesClasses(className)
+  if (!cat) return null
+  return (
+    <Link href={`${CATEGORY_PATH}/${cat.slug}`} className={classes}>
+      {cat.name}
+    </Link>
+  )
+}
+
+const TodayNewsCard = ({
+  id,
+  title,
+  uri,
+  date,
+  featuredImage,
+  categories,
+  customFields
+}: TodayPost) => {
+  const limitedTitle = limitStringCharacters(title)
+  if (!limitedTitle || limitedTitle.length <= 10) return null
+
+  return (
+    <article key={id} className='flex flex-col'>
+      <HoverPrefetchLink
+        href={uri}
+        aria-label={limitedTitle}
+        onClick={() =>
+          GAEvent({
+            category: GA_EVENTS.POST_LINK.SINGLE.CATEGORY,
+            label: 'TODAY_NEWS_CARD'
+          })
+        }
+      >
+        {featuredImage && (
+          <div
+            className='mb-3 w-full'
+            style={{ aspectRatio: '16/9', overflow: 'hidden' }}
+          >
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            <img
+              src={featuredImage.node.sourceUrl}
+              alt={limitedTitle}
+              className='h-full w-full object-cover'
+              loading='lazy'
+            />
+            {customFields?.videodestacado && (
+              <span className='bg-secondary pointer-events-none absolute top-1 right-1 z-20 rounded px-1.5 py-0.5 font-sans text-[10px] font-bold tracking-wide text-white uppercase shadow'>
+                + Video
+              </span>
+            )}
+          </div>
+        )}
+      </HoverPrefetchLink>
+      {categories && (
+        <CategoryLabel
+          categories={categories}
+          className='text-primary pt-1 pb-2 uppercase'
+        />
+      )}
+      <h3 className='text-base leading-snug font-semibold text-slate-900 dark:text-white'>
+        <HoverPrefetchLink
+          href={uri}
+          aria-label={limitedTitle}
+          onClick={() =>
+            GAEvent({
+              category: GA_EVENTS.POST_LINK.SINGLE.CATEGORY,
+              label: 'TODAY_NEWS_CARD'
+            })
+          }
+        >
+          {limitedTitle}
+        </HoverPrefetchLink>
+      </h3>
+      <div className='mt-2 text-xs text-slate-500 dark:text-neutral-400'>
+        <DateTime dateString={date} />
+      </div>
+    </article>
+  )
+}
+
+export { TodayNewsCard }

--- a/src/components/TodayNewsCard/index.tsx
+++ b/src/components/TodayNewsCard/index.tsx
@@ -3,31 +3,10 @@
 import { TodayPost } from '@app/actions/getTodayYesterdayPosts'
 import { DateTime } from '@components/DateTime'
 import { HoverPrefetchLink } from '@components/HoverPrefetchLink'
-import { getPostCategoriesClasses } from '@components/PostCategories/styles'
-import { processCategories } from '@lib/utils/processCategories'
+import { TodayCategoryLabel } from '@components/TodayCategoryLabel'
 import { GAEvent } from '@lib/utils/ga'
-import { GA_EVENTS, CATEGORY_PATH } from '@lib/constants'
+import { GA_EVENTS } from '@lib/constants'
 import { limitStringCharacters } from '@lib/utils/limitStringCharacters'
-import Link from 'next/link'
-
-const CategoryLabel = ({
-  categories,
-  className
-}: {
-  categories: TodayPost['categories']
-  className?: string
-}) => {
-  const processed = processCategories(categories.edges, 1)
-  if (!processed.length) return null
-  const cat = processed[0]?.node
-  const classes = getPostCategoriesClasses(className)
-  if (!cat) return null
-  return (
-    <Link href={`${CATEGORY_PATH}/${cat.slug}`} className={classes}>
-      {cat.name}
-    </Link>
-  )
-}
 
 const TodayNewsCard = ({
   id,
@@ -74,7 +53,7 @@ const TodayNewsCard = ({
         )}
       </HoverPrefetchLink>
       {categories && (
-        <CategoryLabel
+        <TodayCategoryLabel
           categories={categories}
           className='text-primary pt-1 pb-2 uppercase'
         />

--- a/src/components/TodayNewsCard/index.tsx
+++ b/src/components/TodayNewsCard/index.tsx
@@ -55,7 +55,7 @@ const TodayNewsCard = ({
       >
         {featuredImage && (
           <div
-            className='mb-3 w-full'
+            className='relative mb-3 w-full'
             style={{ aspectRatio: '16/9', overflow: 'hidden' }}
           >
             {/* eslint-disable-next-line @next/next/no-img-element */}

--- a/src/lib/hooks/data/useCategoryPosts.ts
+++ b/src/lib/hooks/data/useCategoryPosts.ts
@@ -39,10 +39,15 @@ export function useCategoryPosts({
     await mutate(currentData => {
       if (!currentData || !newData) return currentData
 
+      const existingIds = new Set(currentData.posts.edges.map(e => e.node.id))
+      const dedupedNew = newData.posts.edges.filter(
+        e => !existingIds.has(e.node.id)
+      )
+
       return {
         posts: {
           ...currentData.posts,
-          edges: [...currentData.posts.edges, ...newData.posts.edges]
+          edges: [...currentData.posts.edges, ...dedupedNew]
         }
       }
     }, false)

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -290,6 +290,7 @@ export type PostsFetcherReturn =
 export type LoaderProps = {
   slug: string
   qty: number
+  initialOffset?: number
   fetchMorePosts: (offset: number) => Promise<any>
 }
 


### PR DESCRIPTION
## Summary

- Adds a **Today/Yesterday module** to main category pages (MAIN_MENU slugs: nacionales, sucesos, zulia, internacionales, deportes, tendencias, entretenimiento, salud)
- Hero post renders full-width with a dark gradient overlay for wide images (≥1200px), or image-left/text-right for smaller images — both with `fetchPriority=high` for fast LCP
- Secondary posts render in a 2–3 column grid (rounded to multiples of 3, capped at 6), each with a 16:9 aspect-ratio image
- Posts shown in the module are excluded from the client-side list below (no duplicates); the list always fetches 10 posts
- Category labels on hero and cards are now clickable links to the category page
- Post list thumbnail moved from right side to left side
- Adds `@app/*` alias to Jest `moduleNameMapper`

## Test plan

- [ ] Visit `/categoria/nacionales` — hero module should appear above the list when posts exist from the last 3 days
- [ ] Visit `/categoria/sucesos`, `/categoria/deportes` — same behaviour
- [ ] Visit a sub-category not in MAIN_MENU (e.g. `/categoria/entretenimiento/farandula`) — module should NOT appear
- [ ] Confirm hero post does NOT reappear in the list below
- [ ] Test with no recent posts: module absent, list renders normally
- [ ] Wide image (≥1200px): full-width overlay with gradient and white text
- [ ] Narrow image: image-left / text-right layout with `mt-6` top spacing
- [ ] Load more posts: no duplicate keys, correct pagination offset
- [ ] Category label links navigate to correct category page
- [ ] All 316 unit tests pass (`npm run test:unit`)
- [ ] Lint clean (`npm run lint`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)