### PR TITLE
feat: today/yesterday featured posts module on category pages (#189)

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -81,6 +81,7 @@ const config: Config = {
   testEnvironment: 'jsdom',
   moduleNameMapper: {
     '^.+\\.module\\.(css|sass|scss)$': 'identity-obj-proxy',
+    '^@app/(.*)$': '<rootDir>/src/app/$1',
     '^@components/(.*)$': '<rootDir>/src/components/$1',
     '^@blocks/(.*)$': '<rootDir>/src/blocks/$1',
     '^@lib/(.*)$': '<rootDir>/src/lib/$1',

--- a/src/app/(category)/categoria/[...slug]/page.tsx
+++ b/src/app/(category)/categoria/[...slug]/page.tsx
@@ -16,6 +16,7 @@ import { categoryName, titleFromSlug } from '@lib/utils'
 import { getStaticSlugs } from '@lib/utils/getStaticSlugs'
 import { Suspense } from 'react'
 import { Loading } from '@components/LoadingCategory'
+import { NcolAdSlot } from '@components/NcolAdSlot'
 
 const SLUGS_WITH_TODAY_MODULE = new Set(
   MAIN_MENU.map(item => item.href.split('/').pop()).filter(Boolean)
@@ -89,6 +90,7 @@ export default async function Page(props: {
       <Container className='py-10' sidebar>
         <section className='w-full md:w-2/3 md:pr-8 lg:w-3/4'>
           {shownCount >= 1 && <TodaySecondaryGrid posts={todayPosts!} />}
+          <NcolAdSlot slot='article-top' className='my-4 flex justify-center' />
           <Suspense fallback={<Loading />}>
             <Content slug={slug} excludeIds={excludeIds} />
           </Suspense>

--- a/src/app/(category)/categoria/[...slug]/page.tsx
+++ b/src/app/(category)/categoria/[...slug]/page.tsx
@@ -7,7 +7,8 @@ import { PageTitle } from '@components/PageTitle'
 import { Sidebar } from '@components/Sidebar'
 import {
   TodayHeroSection,
-  TodaySecondaryGrid
+  TodaySecondaryGrid,
+  getSecondaryPosts
 } from '@blocks/content/TodayYesterdayModule'
 import { getTodayYesterdayPosts } from '@app/actions/getTodayYesterdayPosts'
 import { sharedOpenGraph } from '@lib/sharedOpenGraph'
@@ -63,17 +64,11 @@ export default async function Page(props: {
     ? await getTodayYesterdayPosts({ slug })
     : null
 
-  const shownCount = todayPosts?.edges.length ?? 0
-
-  // Mirror the rounding logic in TodayYesterdayModule so we only exclude posts actually rendered.
-  // Secondary grid: rounded down to nearest multiple of 3, capped at 6.
-  const secondaryCount =
-    shownCount >= 3 ? Math.floor(Math.min(shownCount - 1, 6) / 3) * 3 : 0
-  // Total rendered in module: hero (1) + secondary cards
-  const renderedCount = shownCount >= 1 ? 1 + secondaryCount : 0
-
-  const excludeIds =
-    todayPosts?.edges.slice(0, renderedCount).map(e => e.node.id) ?? []
+  const todayEdges = todayPosts?.edges ?? []
+  const secondaryPosts = getSecondaryPosts(todayEdges)
+  const renderedCount = todayEdges[0] ? 1 + secondaryPosts.length : 0
+  const excludeIds = todayEdges.slice(0, renderedCount).map(e => e.node.id)
+  const shownCount = todayEdges.length
 
   return (
     <>

--- a/src/app/(category)/categoria/[...slug]/page.tsx
+++ b/src/app/(category)/categoria/[...slug]/page.tsx
@@ -1,15 +1,24 @@
 export const dynamic = 'force-static'
 
-import { MENU, MENU_B, CATEGORY_PATH } from '@lib/constants'
+import { MENU, MENU_B, MAIN_MENU, CATEGORY_PATH } from '@lib/constants'
 import { Content } from '@blocks/content/CategoryPosts'
 import { Container } from '@components/Container'
 import { PageTitle } from '@components/PageTitle'
 import { Sidebar } from '@components/Sidebar'
+import {
+  TodayHeroSection,
+  TodaySecondaryGrid
+} from '@blocks/content/TodayYesterdayModule'
+import { getTodayYesterdayPosts } from '@app/actions/getTodayYesterdayPosts'
 import { sharedOpenGraph } from '@lib/sharedOpenGraph'
 import { categoryName, titleFromSlug } from '@lib/utils'
 import { getStaticSlugs } from '@lib/utils/getStaticSlugs'
 import { Suspense } from 'react'
 import { Loading } from '@components/LoadingCategory'
+
+const SLUGS_WITH_TODAY_MODULE = new Set(
+  MAIN_MENU.map(item => item.href.split('/').pop()).filter(Boolean)
+)
 
 type Params = { slug: string[] }
 type SearchParams = { [key: string]: string | string[] | undefined }
@@ -49,6 +58,23 @@ export default async function Page(props: {
     ? params.slug[params.slug.length - 1]
     : params.slug
 
+  const hasTodayModule = SLUGS_WITH_TODAY_MODULE.has(slug)
+  const todayPosts = hasTodayModule
+    ? await getTodayYesterdayPosts({ slug })
+    : null
+
+  const shownCount = todayPosts?.edges.length ?? 0
+
+  // Mirror the rounding logic in TodayYesterdayModule so we only exclude posts actually rendered.
+  // Secondary grid: rounded down to nearest multiple of 3, capped at 6.
+  const secondaryCount =
+    shownCount >= 3 ? Math.floor(Math.min(shownCount - 1, 6) / 3) * 3 : 0
+  // Total rendered in module: hero (1) + secondary cards
+  const renderedCount = shownCount >= 1 ? 1 + secondaryCount : 0
+
+  const excludeIds =
+    todayPosts?.edges.slice(0, renderedCount).map(e => e.node.id) ?? []
+
   return (
     <>
       <PageTitle text={titleFromSlug(slug)} />
@@ -64,10 +90,12 @@ export default async function Page(props: {
           <AdSenseBanner className={'min-h-[70px]'} {...ad.global.top_header} />
         </div>
       </div> */}
+      {shownCount >= 1 && <TodayHeroSection posts={todayPosts!} />}
       <Container className='py-10' sidebar>
         <section className='w-full md:w-2/3 md:pr-8 lg:w-3/4'>
+          {shownCount >= 1 && <TodaySecondaryGrid posts={todayPosts!} />}
           <Suspense fallback={<Loading />}>
-            <Content slug={slug} />
+            <Content slug={slug} excludeIds={excludeIds} />
           </Suspense>
         </section>
         <Sidebar />

--- a/src/app/(sidebar)/dolar-hoy/page.tsx
+++ b/src/app/(sidebar)/dolar-hoy/page.tsx
@@ -11,6 +11,7 @@ import { Loading } from '@components/LoadingCategory'
 
 import { DollarCalculator } from '@components/DollarCalculator'
 import { DOLAR_HOY_SLUG } from '@lib/constants'
+import { NcolAdSlot } from '@components/NcolAdSlot'
 
 export async function generateMetadata() {
   return {
@@ -28,6 +29,7 @@ export default function Page() {
       <Container className='py-10' sidebar>
         <section className='w-full md:w-2/3 md:pr-8 lg:w-3/4'>
           <DollarCalculator />
+          <NcolAdSlot slot='article-top' className='my-4 flex justify-center' />
           <Suspense fallback={<Loading />}>
             <Content slug={slug} />
           </Suspense>

--- a/src/app/actions/getFeaturedPost/index.ts
+++ b/src/app/actions/getFeaturedPost/index.ts
@@ -15,7 +15,7 @@ export async function getFeaturedPost(): Promise<PostHome | null> {
   const [featuredData, fallbackData] = await Promise.all([
     cachedFetchAPI<PostsResult>({
       query: queryFeaturedPost,
-      revalidate: TIME_REVALIDATE.HOUR
+      revalidate: TIME_REVALIDATE.FIFTEEN_MINUTES
     }),
     cachedFetchAPI<PostsResult>({
       query: queryLatestFromCategory,

--- a/src/app/actions/getFeaturedPost/index.ts
+++ b/src/app/actions/getFeaturedPost/index.ts
@@ -15,7 +15,7 @@ export async function getFeaturedPost(): Promise<PostHome | null> {
   const [featuredData, fallbackData] = await Promise.all([
     cachedFetchAPI<PostsResult>({
       query: queryFeaturedPost,
-      revalidate: TIME_REVALIDATE.FIFTEEN_MINUTES
+      revalidate: TIME_REVALIDATE.HOUR
     }),
     cachedFetchAPI<PostsResult>({
       query: queryLatestFromCategory,

--- a/src/app/actions/getTodayYesterdayPosts/__tests__/getTodayYesterdayPosts.test.ts
+++ b/src/app/actions/getTodayYesterdayPosts/__tests__/getTodayYesterdayPosts.test.ts
@@ -1,0 +1,63 @@
+import { getTodayYesterdayPosts } from '..'
+
+jest.mock('@app/actions/fetchAPI', () => ({
+  cachedFetchAPI: jest.fn()
+}))
+
+import { cachedFetchAPI } from '@app/actions/fetchAPI'
+
+const mockFetch = cachedFetchAPI as jest.Mock
+
+const makeEdge = (daysAgo: number) => {
+  const d = new Date()
+  d.setDate(d.getDate() - daysAgo)
+  return {
+    node: {
+      id: `id-${daysAgo}`,
+      title: `Post ${daysAgo}`,
+      uri: `/post-${daysAgo}`,
+      date: d.toISOString(),
+      categories: { edges: [] }
+    }
+  }
+}
+
+describe('getTodayYesterdayPosts', () => {
+  beforeEach(() => jest.clearAllMocks())
+
+  test('returns null when API returns no data', async () => {
+    mockFetch.mockResolvedValue(null)
+    const result = await getTodayYesterdayPosts({ slug: 'nacionales' })
+    expect(result).toBeNull()
+  })
+
+  test('returns null when posts field is missing', async () => {
+    mockFetch.mockResolvedValue({})
+    const result = await getTodayYesterdayPosts({ slug: 'nacionales' })
+    expect(result).toBeNull()
+  })
+
+  test('filters out posts older than 3 days', async () => {
+    const recent = makeEdge(1)
+    const old = makeEdge(5)
+    mockFetch.mockResolvedValue({ posts: { edges: [recent, old] } })
+    const result = await getTodayYesterdayPosts({ slug: 'nacionales' })
+    expect(result?.edges).toHaveLength(1)
+    expect(result?.edges[0]?.node.id).toBe('id-1')
+  })
+
+  test('includes posts from today and within 3 days', async () => {
+    const edges = [makeEdge(0), makeEdge(1), makeEdge(2), makeEdge(3)]
+    mockFetch.mockResolvedValue({ posts: { edges } })
+    const result = await getTodayYesterdayPosts({ slug: 'nacionales' })
+    expect(result?.edges.length).toBeGreaterThanOrEqual(3)
+  })
+
+  test('returns empty edges array when all posts are too old', async () => {
+    mockFetch.mockResolvedValue({
+      posts: { edges: [makeEdge(10), makeEdge(7)] }
+    })
+    const result = await getTodayYesterdayPosts({ slug: 'nacionales' })
+    expect(result?.edges).toHaveLength(0)
+  })
+})

--- a/src/app/actions/getTodayYesterdayPosts/index.ts
+++ b/src/app/actions/getTodayYesterdayPosts/index.ts
@@ -1,0 +1,81 @@
+'use server'
+
+import { cachedFetchAPI } from '@app/actions/fetchAPI'
+import { TIME_REVALIDATE } from '@lib/constants'
+import { queryTodayYesterdayPosts } from './query'
+
+export interface TodayPost {
+  id: string
+  title: string
+  uri: string
+  date: string
+  excerpt?: string
+  featuredImage?: {
+    node: {
+      sourceUrl: string
+      srcSet?: string
+      mediaDetails?: {
+        width: number
+        height: number
+      }
+    }
+  }
+  categories: {
+    edges: {
+      node: {
+        name: string
+        slug: string
+        parentId?: string | null
+      }
+    }[]
+    type: string
+    className?: string
+    slice?: number
+  }
+  customFields?: {
+    videodestacado?: string
+  }
+}
+
+export interface TodayPostsResult {
+  edges: { node: TodayPost }[]
+}
+
+function getRecentCutoffDateInCaracas(): string {
+  // America/Caracas is UTC-4 (no DST).
+  // Use 3 days as the cutoff so slow news days (e.g. weekends) don't produce
+  // an empty module. Posts older than 3 days are excluded by the filter below.
+  const cutoff = new Date()
+  cutoff.setUTCDate(cutoff.getUTCDate() - 3)
+  // Format in Caracas time directly, independent of host timezone.
+  return new Intl.DateTimeFormat('en-CA', {
+    timeZone: 'America/Caracas',
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit'
+  }).format(cutoff) // "YYYY-MM-DD"
+}
+
+export async function getTodayYesterdayPosts({
+  slug
+}: {
+  slug: string
+}): Promise<TodayPostsResult | null> {
+  const recentCutoff = getRecentCutoffDateInCaracas()
+
+  const data = await cachedFetchAPI<{ posts: TodayPostsResult }>({
+    query: queryTodayYesterdayPosts,
+    variables: { slug },
+    revalidate: TIME_REVALIDATE.HOUR
+  })
+
+  if (!data?.posts) return null
+
+  // Filter to only posts within the recent cutoff window (Caracas time)
+  const filteredEdges = data.posts.edges.filter(({ node }) => {
+    const postDate = node.date.split('T')[0]
+    return postDate !== undefined && postDate >= recentCutoff
+  })
+
+  return { edges: filteredEdges }
+}

--- a/src/app/actions/getTodayYesterdayPosts/index.ts
+++ b/src/app/actions/getTodayYesterdayPosts/index.ts
@@ -28,9 +28,6 @@ export interface TodayPost {
         parentId?: string | null
       }
     }[]
-    type: string
-    className?: string
-    slice?: number
   }
   customFields?: {
     videodestacado?: string

--- a/src/app/actions/getTodayYesterdayPosts/query.ts
+++ b/src/app/actions/getTodayYesterdayPosts/query.ts
@@ -1,0 +1,46 @@
+import { IMAGE_SIZES } from '@lib/constants'
+
+export const queryTodayYesterdayPosts = `
+query TodayYesterdayPosts($slug: String!) {
+  posts(
+    first: 7
+    where: {
+      orderby: { field: DATE, order: DESC }
+      categoryName: $slug
+      status: PUBLISH
+    }
+  ) {
+    edges {
+      node {
+        id
+        title
+        uri
+        date
+        excerpt
+        featuredImage {
+          node {
+            sourceUrl(size: ${IMAGE_SIZES.LARGE})
+            srcSet
+            mediaDetails {
+              width
+              height
+            }
+          }
+        }
+        categories {
+          edges {
+            node {
+              name
+              slug
+              parentId
+            }
+          }
+        }
+        customFields {
+          videodestacado
+        }
+      }
+    }
+  }
+}
+`

--- a/src/app/api/track/route.ts
+++ b/src/app/api/track/route.ts
@@ -87,3 +87,19 @@ export async function POST(req: NextRequest) {
 
   return Response.json({ ok: true })
 }
+
+export async function GET() {
+  return Response.json({ ok: true, message: 'Tracking endpoint' })
+}
+
+export async function OPTIONS() {
+  return new Response(null, {
+    status: 204,
+    headers: {
+      'Access-Control-Allow-Origin': '*',
+      'Access-Control-Allow-Methods': 'GET, POST, OPTIONS',
+      'Access-Control-Allow-Headers': 'Content-Type, Authorization',
+      'Access-Control-Max-Age': '86400'
+    }
+  })
+}

--- a/src/app/api/track/route.ts
+++ b/src/app/api/track/route.ts
@@ -1,11 +1,35 @@
 import { NextRequest } from 'next/server'
 
-interface TrackBody {
+interface TrackItem {
   ad_id: string
   slot: string
   date: string
   views: number
   clicks: number
+}
+
+interface TrackBody {
+  ads: TrackItem[]
+}
+
+function safeCount(n: number, max: number) {
+  return Math.min(Math.max(0, Number.isFinite(n) ? Math.floor(n) : 0), max)
+}
+
+function itemToEvents(
+  item: TrackItem,
+  timestamp: string,
+  max: number
+): Record<string, unknown>[] {
+  const { ad_id, slot, date, views, clicks } = item
+  if (!ad_id || !slot || !date) return []
+  const out: Record<string, unknown>[] = []
+  const base = { ad_id, slot, date, occurred_at: timestamp }
+  for (let i = 0; i < safeCount(views, max); i++)
+    out.push({ ...base, event_type: 'view' })
+  for (let i = 0; i < safeCount(clicks, max); i++)
+    out.push({ ...base, event_type: 'click' })
+  return out
 }
 
 export async function POST(req: NextRequest) {
@@ -16,45 +40,15 @@ export async function POST(req: NextRequest) {
     return Response.json({ error: 'invalid json' }, { status: 400 })
   }
 
-  const { ad_id, slot, date, views, clicks } = body
-  if (!ad_id || !slot || !date) {
-    return Response.json(
-      { error: 'ad_id, slot, date required' },
-      { status: 400 }
-    )
+  if (!Array.isArray(body?.ads) || body.ads.length === 0) {
+    return Response.json({ error: 'ads array required' }, { status: 400 })
   }
 
   const MAX_EVENTS = 100
-  const safeViews = Math.min(
-    Math.max(0, Number.isFinite(views) ? Math.floor(views) : 0),
-    MAX_EVENTS
-  )
-  const safeClicks = Math.min(
-    Math.max(0, Number.isFinite(clicks) ? Math.floor(clicks) : 0),
-    MAX_EVENTS
-  )
-
   const timestamp = new Date().toISOString().replace('T', ' ').slice(0, 19)
-  const events: Record<string, unknown>[] = []
-
-  for (let i = 0; i < safeViews; i++) {
-    events.push({
-      ad_id,
-      event_type: 'view',
-      slot,
-      date,
-      occurred_at: timestamp
-    })
-  }
-  for (let i = 0; i < safeClicks; i++) {
-    events.push({
-      ad_id,
-      event_type: 'click',
-      slot,
-      date,
-      occurred_at: timestamp
-    })
-  }
+  const events = body.ads.flatMap(item =>
+    itemToEvents(item, timestamp, MAX_EVENTS)
+  )
 
   if (events.length === 0) {
     return Response.json({ ok: true })

--- a/src/app/api/track/route.ts
+++ b/src/app/api/track/route.ts
@@ -98,7 +98,7 @@ export async function OPTIONS() {
     headers: {
       'Access-Control-Allow-Origin': '*',
       'Access-Control-Allow-Methods': 'GET, POST, OPTIONS',
-      'Access-Control-Allow-Headers': 'Content-Type, Authorization',
+      'Access-Control-Allow-Headers': 'Content-Type',
       'Access-Control-Max-Age': '86400'
     }
   })

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,4 +1,4 @@
-export const revalidate = 3600
+export const revalidate = 900
 
 import { Suspense } from 'react'
 

--- a/src/blocks/content/CategoryPosts/index.tsx
+++ b/src/blocks/content/CategoryPosts/index.tsx
@@ -7,6 +7,7 @@ import { AdSenseBanner } from '@components/AdSenseBanner'
 import { CategoryArticle } from '@components/CategoryArticle'
 import { Loading } from '@components/LoadingCategory'
 import { Newsletter } from '@components/Newsletter'
+import { NcolAdSlot } from '@components/NcolAdSlot'
 import { ad } from '@lib/ads'
 import { useCategoryPosts } from '@lib/hooks/data/useCategoryPosts'
 import { NotFoundAlert } from '@components/NotFoundAlert'
@@ -14,13 +15,20 @@ import { LoaderCategoryPosts } from '@components/LoaderCategoryPosts'
 
 const postsQty = Number(process.env.NEXT_PUBLIC_POSTS_QTY_CATEGORY ?? 10)
 
-export const Content = ({ slug }: { slug: string }) => {
+export const Content = ({
+  slug,
+  excludeIds = []
+}: {
+  slug: string
+  excludeIds?: string[]
+}) => {
+  const fetchQty = postsQty + excludeIds.length
   const {
     data: result,
     error,
     isLoading,
     fetchMorePosts
-  } = useCategoryPosts({ slug, qty: postsQty, offset: 0 })
+  } = useCategoryPosts({ slug, qty: fetchQty, offset: 0 })
 
   if (error) {
     Sentry.captureException(error, {
@@ -38,10 +46,21 @@ export const Content = ({ slug }: { slug: string }) => {
     return <NotFoundAlert />
   }
 
-  const { edges } = result ?? { edges: [] }
+  const allEdges = result?.edges ?? []
+  const excludeSet = new Set(excludeIds)
+  const edges =
+    excludeSet.size > 0
+      ? allEdges.filter(({ node }) => !excludeSet.has(node.id ?? ''))
+      : allEdges
 
   return (
     <>
+      {excludeIds.length > 0 && (
+        <>
+          <NcolAdSlot slot='article-top' className='my-4 flex justify-center' />
+        </>
+      )}
+      <hr className='mb-6' />
       {edges.map(({ node }, index) => (
         <Fragment key={node.id}>
           <CategoryArticle
@@ -65,6 +84,7 @@ export const Content = ({ slug }: { slug: string }) => {
         <LoaderCategoryPosts
           slug={slug}
           qty={postsQty}
+          initialOffset={fetchQty}
           fetchMorePosts={fetchMorePosts}
         />
       )}

--- a/src/blocks/content/CategoryPosts/index.tsx
+++ b/src/blocks/content/CategoryPosts/index.tsx
@@ -56,9 +56,7 @@ export const Content = ({
   return (
     <>
       {excludeIds.length > 0 && (
-        <>
-          <NcolAdSlot slot='article-top' className='my-4 flex justify-center' />
-        </>
+        <NcolAdSlot slot='article-top' className='my-4 flex justify-center' />
       )}
       <hr className='mb-6' />
       {edges.map(({ node }, index) => (

--- a/src/blocks/content/CategoryPosts/index.tsx
+++ b/src/blocks/content/CategoryPosts/index.tsx
@@ -7,7 +7,6 @@ import { AdSenseBanner } from '@components/AdSenseBanner'
 import { CategoryArticle } from '@components/CategoryArticle'
 import { Loading } from '@components/LoadingCategory'
 import { Newsletter } from '@components/Newsletter'
-import { NcolAdSlot } from '@components/NcolAdSlot'
 import { ad } from '@lib/ads'
 import { useCategoryPosts } from '@lib/hooks/data/useCategoryPosts'
 import { NotFoundAlert } from '@components/NotFoundAlert'
@@ -55,9 +54,6 @@ export const Content = ({
 
   return (
     <>
-      {excludeIds.length > 0 && (
-        <NcolAdSlot slot='article-top' className='my-4 flex justify-center' />
-      )}
       <hr className='mb-6' />
       {edges.map(({ node }, index) => (
         <Fragment key={node.id}>

--- a/src/blocks/content/CategoryPosts/index.tsx
+++ b/src/blocks/content/CategoryPosts/index.tsx
@@ -28,7 +28,7 @@ export const Content = ({
     error,
     isLoading,
     fetchMorePosts
-  } = useCategoryPosts({ slug, qty: fetchQty, offset: 0 })
+  } = useCategoryPosts({ slug, qty: postsQty, initialQty: fetchQty, offset: 0 })
 
   if (error) {
     Sentry.captureException(error, {

--- a/src/blocks/content/TodayYesterdayModule/__tests__/TodayYesterdayModule.test.tsx
+++ b/src/blocks/content/TodayYesterdayModule/__tests__/TodayYesterdayModule.test.tsx
@@ -44,8 +44,7 @@ describe('getSecondaryPosts', () => {
     expect(getSecondaryPosts(makePosts(20).edges)).toHaveLength(6)
   })
 
-  test('returns 3 when exactly 3 total (hero + 2 = 2 secondary, rounds to 0? no: 3 total → 2 secondary → rounds to 0)', () => {
-    // 3 total: hero=1, remaining=2, capped=2, rounded=floor(2/3)*3=0
+  test('returns 0 when exactly 3 total (hero=1, remaining=2, floor(2/3)*3=0)', () => {
     expect(getSecondaryPosts(makePosts(3).edges)).toHaveLength(0)
   })
 

--- a/src/blocks/content/TodayYesterdayModule/__tests__/TodayYesterdayModule.test.tsx
+++ b/src/blocks/content/TodayYesterdayModule/__tests__/TodayYesterdayModule.test.tsx
@@ -1,0 +1,80 @@
+import { render, screen } from '@testing-library/react'
+import { getSecondaryPosts, TodayHeroSection, TodaySecondaryGrid } from '..'
+import { TodayPostsResult } from '@app/actions/getTodayYesterdayPosts'
+
+jest.mock('@components/TodayHeroPost', () => ({
+  TodayHeroPost: ({ title }: any) => <div data-testid='hero'>{title}</div>
+}))
+jest.mock('@components/TodayNewsCard', () => ({
+  TodayNewsCard: ({ title }: any) => <div data-testid='card'>{title}</div>
+}))
+
+const makePost = (id: string) => ({
+  node: {
+    id,
+    title: `Post ${id}`,
+    uri: `/post-${id}`,
+    date: '2026-04-23T10:00:00',
+    categories: { edges: [] }
+  }
+})
+
+const makePosts = (count: number): TodayPostsResult => ({
+  edges: Array.from({ length: count }, (_, i) => makePost(String(i + 1)))
+})
+
+describe('getSecondaryPosts', () => {
+  test('returns empty array when fewer than 3 posts', () => {
+    expect(getSecondaryPosts(makePosts(2).edges)).toEqual([])
+  })
+
+  test('returns 3 posts when 4 total (rounds down to multiple of 3)', () => {
+    expect(getSecondaryPosts(makePosts(4).edges)).toHaveLength(3)
+  })
+
+  test('returns 3 posts when exactly 4 total', () => {
+    expect(getSecondaryPosts(makePosts(4).edges)).toHaveLength(3)
+  })
+
+  test('returns 6 posts when 7 total (hero + 6 secondary)', () => {
+    expect(getSecondaryPosts(makePosts(7).edges)).toHaveLength(6)
+  })
+
+  test('caps at 6 secondary posts even with more input', () => {
+    expect(getSecondaryPosts(makePosts(20).edges)).toHaveLength(6)
+  })
+
+  test('returns 3 when exactly 3 total (hero + 2 = 2 secondary, rounds to 0? no: 3 total → 2 secondary → rounds to 0)', () => {
+    // 3 total: hero=1, remaining=2, capped=2, rounded=floor(2/3)*3=0
+    expect(getSecondaryPosts(makePosts(3).edges)).toHaveLength(0)
+  })
+
+  test('returns 3 when 4 posts', () => {
+    // 4 total: hero=1, remaining=3, capped=3, rounded=3
+    expect(getSecondaryPosts(makePosts(4).edges)).toHaveLength(3)
+  })
+})
+
+describe('TodayHeroSection', () => {
+  test('renders nothing when no posts', () => {
+    const { container } = render(<TodayHeroSection posts={{ edges: [] }} />)
+    expect(container.firstChild).toBeNull()
+  })
+
+  test('renders hero post', () => {
+    render(<TodayHeroSection posts={makePosts(1)} />)
+    expect(screen.getByTestId('hero')).toBeInTheDocument()
+  })
+})
+
+describe('TodaySecondaryGrid', () => {
+  test('renders nothing when fewer than 3 posts', () => {
+    const { container } = render(<TodaySecondaryGrid posts={makePosts(2)} />)
+    expect(container.firstChild).toBeNull()
+  })
+
+  test('renders cards for secondary posts', () => {
+    render(<TodaySecondaryGrid posts={makePosts(7)} />)
+    expect(screen.getAllByTestId('card')).toHaveLength(6)
+  })
+})

--- a/src/blocks/content/TodayYesterdayModule/index.tsx
+++ b/src/blocks/content/TodayYesterdayModule/index.tsx
@@ -1,0 +1,57 @@
+import {
+  TodayPost,
+  TodayPostsResult
+} from '@app/actions/getTodayYesterdayPosts'
+import { TodayHeroPost } from '@components/TodayHeroPost'
+import { TodayNewsCard } from '@components/TodayNewsCard'
+
+interface Props {
+  posts: TodayPostsResult
+}
+
+export function getSecondaryPosts(
+  edges: TodayPostsResult['edges']
+): TodayPost[] {
+  if (edges.length < 3) return []
+  const raw = edges.slice(1).map(({ node }) => node)
+  const capped = Math.min(raw.length, 6)
+  // Round down to nearest multiple of 3 so the grid never has an orphan card.
+  const rounded = Math.floor(capped / 3) * 3
+  return raw.slice(0, rounded)
+}
+
+// Full-width hero — rendered outside the sidebar Container
+const TodayHeroSection = ({ posts }: Props) => {
+  const heroPost = posts.edges[0]?.node
+  if (!heroPost) return null
+
+  return (
+    <div className='container mx-auto px-6 pt-0 sm:px-7 sm:pt-6'>
+      <TodayHeroPost {...heroPost} />
+    </div>
+  )
+}
+
+// Secondary cards grid — rendered inside the sidebar column
+const TodaySecondaryGrid = ({ posts }: Props) => {
+  const secondaryPosts = getSecondaryPosts(posts.edges)
+  if (secondaryPosts.length === 0) return null
+
+  const mobileColClass =
+    secondaryPosts.length === 3
+      ? 'grid-cols-1 sm:grid-cols-3'
+      : 'grid-cols-2 md:grid-cols-3'
+
+  return (
+    <section className='mb-8'>
+      <hr className='mb-4 border-slate-200 dark:border-neutral-600' />
+      <div className={`grid gap-4 ${mobileColClass}`}>
+        {secondaryPosts.map(post => (
+          <TodayNewsCard key={post.id} {...post} />
+        ))}
+      </div>
+    </section>
+  )
+}
+
+export { TodayHeroSection, TodaySecondaryGrid }

--- a/src/components/CategoryArticle/index.tsx
+++ b/src/components/CategoryArticle/index.tsx
@@ -51,6 +51,25 @@ const CategoryArticle = ({
 
   return (
     <article key={id} className={classes}>
+      {featuredImage && typeIs(LIST) && (
+        <div className={classesImage}>
+          <div style={{ width: '100%', height: '100%', position: 'relative' }}>
+            <LazyImage
+              uri={uri}
+              title={limitedTitle}
+              coverImage={featuredImage?.node.sourceUrl}
+              srcSet={featuredImage?.node.sourceUrl}
+              className={classesCoverImage}
+              size={imageSize}
+            />
+            {customFields?.videodestacado && (
+              <span className='bg-secondary pointer-events-none absolute top-1 right-1 z-20 rounded p-1 px-1.5 py-0.5 font-sans text-[10px] font-bold tracking-wide text-white uppercase shadow'>
+                + Video
+              </span>
+            )}
+          </div>
+        </div>
+      )}
       <div className={classesContentWrapper}>
         {categories && (typeIs(THUMBNAIL) || typeIs(LIST)) && (
           <div className={`${!typeIs(THUMBNAIL) && 'mb-1'}`}>
@@ -88,7 +107,7 @@ const CategoryArticle = ({
           </div>
         )}
       </div>
-      {featuredImage && (
+      {featuredImage && !typeIs(LIST) && (
         <div className={classesImage}>
           {categories &&
             (typeIs(SECONDARY) || typeIs(SIDEBAR) || typeIs(RECENT_NEWS)) && (

--- a/src/components/CategoryArticle/styles.ts
+++ b/src/components/CategoryArticle/styles.ts
@@ -46,7 +46,7 @@ export const getCategoryArticleClasses = ({
 export const getImageClasses = ({ type }: { type: string }) =>
   cn(
     {
-      'mt-8 ml-3 h-16 w-20 sm:mt-0 sm:ml-5 sm:h-28 sm:w-40 lg:h-32 lg:w-48':
+      'mt-9 mr-3 h-16 w-20 sm:mt-2 sm:mr-5 sm:h-28 sm:w-40 lg:h-32 lg:w-48':
         typeIs(type, LIST)
     },
     {
@@ -73,10 +73,8 @@ export const getImageClasses = ({ type }: { type: string }) =>
 export const getTitleClasses = ({ type }: { type: string }) =>
   cn(
     {
-      'mb-3 font-sans text-lg leading-7 font-bold sm:text-xl': typeIs(
-        type,
-        LIST
-      )
+      'mb-3 font-sans text-lg leading-snug font-bold sm:text-xl sm:leading-7':
+        typeIs(type, LIST)
     },
     {
       'text-basemt-2 mb-3 font-sans leading-6 font-bold sm:leading-7 md:mb-2 md:text-lg':

--- a/src/components/Footer/__tests__/__snapshots__/Footer.test.tsx.snap
+++ b/src/components/Footer/__tests__/__snapshots__/Footer.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`Footer should match snapshots 1`] = `
     class="footer bg-dark-blue relative text-sm text-slate-300 dark:bg-neutral-800"
   >
     <div
-      class="flex justify-center overflow-hidden bg-white py-2"
+      class="flex justify-center bg-white py-2"
       style="min-height: 90px;"
     />
     <button

--- a/src/components/Footer/__tests__/__snapshots__/Footer.test.tsx.snap
+++ b/src/components/Footer/__tests__/__snapshots__/Footer.test.tsx.snap
@@ -5,6 +5,10 @@ exports[`Footer should match snapshots 1`] = `
   <footer
     class="footer bg-dark-blue relative text-sm text-slate-300 dark:bg-neutral-800"
   >
+    <div
+      class="flex justify-center overflow-hidden bg-white py-2"
+      style="min-height: 90px;"
+    />
     <button
       aria-label="Ir al inicio de la página"
       class="link-go-top bg-primary absolute -top-3 right-6 h-9 w-9 cursor-pointer rounded-sm border-none text-white duration-150 ease-in hover:-top-4"

--- a/src/components/Footer/index.tsx
+++ b/src/components/Footer/index.tsx
@@ -22,10 +22,7 @@ const Footer = () => {
 
   return (
     <footer className='footer bg-dark-blue relative text-sm text-slate-300 dark:bg-neutral-800'>
-      <NcolAdSlot
-        slot='footer'
-        className='flex justify-center overflow-hidden bg-white py-2'
-      />
+      <NcolAdSlot slot='footer' className='flex justify-center bg-white py-2' />
       <ButtonGoTop />
       <div className='bg-dark-blue text-xs dark:bg-neutral-800'>
         <Container className='pt-12 pb-8'>

--- a/src/components/LoaderCategoryPosts/index.tsx
+++ b/src/components/LoaderCategoryPosts/index.tsx
@@ -7,8 +7,13 @@ import { useState } from 'react'
 import { GAEvent } from '@lib/utils'
 import * as Sentry from '@sentry/nextjs'
 
-const LoaderCategoryPosts = ({ slug, qty, fetchMorePosts }: LoaderProps) => {
-  const [offset, setOffset] = useState(qty)
+const LoaderCategoryPosts = ({
+  slug,
+  qty,
+  initialOffset,
+  fetchMorePosts
+}: LoaderProps) => {
+  const [offset, setOffset] = useState(initialOffset ?? qty)
   const [status, setStatus] = useState<string>(STATUS.Success)
 
   const handleLoadMore = async () => {

--- a/src/components/LoaderSinglePosts/index.tsx
+++ b/src/components/LoaderSinglePosts/index.tsx
@@ -97,10 +97,7 @@ const LoadedPost = ({
 
   return (
     <div>
-      <NcolAdSlot
-        slot='footer'
-        className='flex justify-center overflow-hidden bg-white py-2'
-      />
+      <NcolAdSlot slot='footer' className='flex justify-center bg-white py-2' />
       <div
         className='border-t border-slate-200 dark:border-neutral-500'
         ref={setRefs}

--- a/src/components/NcolAdSlot/__tests__/NcolAdSlot.test.tsx
+++ b/src/components/NcolAdSlot/__tests__/NcolAdSlot.test.tsx
@@ -59,10 +59,11 @@ describe('NcolAdSlot', () => {
     expect(container.firstChild).toBeNull()
   })
 
-  it('renders nothing when no ad is available for a non-header slot', () => {
+  it('renders a height placeholder when no ad is available for a non-header slot', () => {
     mockPickAd.mockReturnValue(null)
     const { container } = render(<NcolAdSlot slot='inline' />)
-    expect(container.firstChild).toBeNull()
+    expect(container.firstChild).not.toBeNull()
+    expect((container.firstChild as HTMLElement).style.minHeight).toBeTruthy()
   })
 
   it('renders banner image when ad type is banner', async () => {

--- a/src/components/NcolAdSlot/index.tsx
+++ b/src/components/NcolAdSlot/index.tsx
@@ -170,8 +170,9 @@ function useViewTracking(ad: ServedAd | null | undefined) {
                 localStorage.setItem(kV, String(getCount(kV) + 1))
                 localStorage.setItem(`ncol_slot_${ad.id}`, ad.slot)
               }
+              timer = null
               observer.disconnect()
-            }, 1000)
+            }, 300)
           } else {
             if (timer) {
               clearTimeout(timer)
@@ -184,7 +185,17 @@ function useViewTracking(ad: ServedAd | null | undefined) {
       observer.observe(el)
       cleanupRef.current = () => {
         observer.disconnect()
-        if (timer) clearTimeout(timer)
+        if (timer) {
+          // Ad was visible when unmounting (navigation) — count the view immediately
+          clearTimeout(timer)
+          timer = null
+          if (ADS_TRACKING_ENABLED) {
+            const today = new Date().toISOString().slice(0, 10)
+            const kV = `ncol_v_${ad.id}_${today}`
+            localStorage.setItem(kV, String(getCount(kV) + 1))
+            localStorage.setItem(`ncol_slot_${ad.id}`, ad.slot)
+          }
+        }
       }
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/src/components/NcolAdSlot/index.tsx
+++ b/src/components/NcolAdSlot/index.tsx
@@ -19,6 +19,13 @@ function useIsMobile() {
   return mobile
 }
 
+function getSlotHeight(slot: string, mobile: boolean) {
+  // eslint-disable-next-line security/detect-object-injection
+  const dims = SLOT_DIMENSIONS[slot]
+  if (!dims) return undefined
+  return mobile ? dims.mobile[1] : dims.desktop[1]
+}
+
 // Slot dimensions mirrored from ncol-ads-dashboard/src/lib/constants.ts SLOT_CONFIG
 const SLOT_DIMENSIONS: Record<
   string,
@@ -179,7 +186,7 @@ function useViewTracking(ad: ServedAd | null | undefined) {
 
 function AdLabel() {
   return (
-    <span className='pointer-events-none absolute top-1 left-1 z-[1] rounded-sm bg-white/85 px-1 py-0.5 text-[9px] leading-none tracking-[0.05em] text-gray-400 select-none'>
+    <span className='pointer-events-none absolute -top-4 left-0 z-[1] rounded-sm bg-white/85 px-1 py-0.5 text-[9px] leading-none tracking-[0.05em] text-gray-400 select-none'>
       PUBLICIDAD
     </span>
   )
@@ -195,14 +202,18 @@ interface PlaceholderProps {
 
 function NcolAdSlotPlaceholder({ slot, className, style }: PlaceholderProps) {
   const mobile = useIsMobile()
-  const dims = Object.prototype.hasOwnProperty.call(SLOT_DIMENSIONS, slot)
-    ? SLOT_DIMENSIONS[slot] // eslint-disable-line security/detect-object-injection
-    : undefined
+  const h = getSlotHeight(slot, mobile)
+  // eslint-disable-next-line security/detect-object-injection
+  const dims = SLOT_DIMENSIONS[slot]
+
   if (!dims) return null
-  const [w, h] = mobile ? dims.mobile : dims.desktop
-  const src = `https://placehold.co/${w}x${h}.png`
+  const [w, height] = mobile ? dims.mobile : dims.desktop
+  const src = `https://placehold.co/${w}x${height}.png`
   return (
-    <div className={className} style={style}>
+    <div
+      className={className}
+      style={{ ...style, minHeight: h ? `${h}px` : undefined }}
+    >
       <div className='relative'>
         <AdLabel />
         {/* eslint-disable-next-line @next/next/no-img-element */}
@@ -210,7 +221,7 @@ function NcolAdSlotPlaceholder({ slot, className, style }: PlaceholderProps) {
           src={src}
           alt={`Placeholder ${slot}`}
           width={w}
-          height={h}
+          height={height}
           className='block h-auto max-w-full'
         />
       </div>
@@ -241,12 +252,10 @@ function NcolAdSlotInner({ slot, className, priority }: NcolAdSlotProps) {
   const viewRef = useViewTracking(ad)
   const mobile = useIsMobile()
 
-  let reservedHeight: number | undefined
-  if (slot === 'header' && RESERVE_HEADER_HEIGHT) {
-    reservedHeight = mobile
-      ? SLOT_DIMENSIONS.header.mobile[1]
-      : SLOT_DIMENSIONS.header.desktop[1]
-  }
+  const reservedHeight =
+    slot === 'header' && RESERVE_HEADER_HEIGHT
+      ? getSlotHeight(slot, mobile)
+      : undefined
 
   useEffect(() => {
     if (!ad) return
@@ -303,8 +312,13 @@ function NcolAdSlotInner({ slot, className, priority }: NcolAdSlotProps) {
   }
 
   if (!ad) {
-    if (slot === 'header' && RESERVE_HEADER_HEIGHT) {
-      return <div className={className} style={{ height: reservedHeight }} />
+    if (reservedHeight) {
+      return (
+        <div
+          className={className}
+          style={{ minHeight: `${reservedHeight}px` }}
+        />
+      )
     }
     return null
   }
@@ -314,7 +328,9 @@ function NcolAdSlotInner({ slot, className, priority }: NcolAdSlotProps) {
       <div
         ref={viewRef}
         className={className}
-        style={{ height: reservedHeight }}
+        style={{
+          minHeight: reservedHeight ? `${reservedHeight}px` : undefined
+        }}
       >
         <div className='relative'>
           <AdLabel />
@@ -342,7 +358,9 @@ function NcolAdSlotInner({ slot, className, priority }: NcolAdSlotProps) {
       <div
         ref={viewRef}
         className={className}
-        style={{ height: reservedHeight }}
+        style={{
+          minHeight: reservedHeight ? `${reservedHeight}px` : undefined
+        }}
       >
         {/* eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions */}
         <div className='relative' onClick={handleClick}>

--- a/src/components/NcolAdSlot/index.tsx
+++ b/src/components/NcolAdSlot/index.tsx
@@ -50,19 +50,29 @@ function getCount(k: string) {
   return parseInt(localStorage.getItem(k) ?? '0', 10)
 }
 
-async function sendTrack(
-  adId: string,
-  slot: string,
-  date: string,
-  views: number,
+interface TrackItem {
+  adId: string
+  slot: string
+  date: string
+  views: number
   clicks: number
-) {
+}
+
+async function sendBatchTrack(items: TrackItem[]) {
   try {
     const res = await fetch('/api/track/', {
       method: 'POST',
       keepalive: true,
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ ad_id: adId, slot, date, views, clicks })
+      body: JSON.stringify({
+        ads: items.map(({ adId, slot, date, views, clicks }) => ({
+          ad_id: adId,
+          slot,
+          date,
+          views,
+          clicks
+        }))
+      })
     })
     return res.ok
   } catch {
@@ -70,67 +80,67 @@ async function sendTrack(
   }
 }
 
-const flushingKeys = new Set<string>()
+let isFlushing = false
 
-async function flush(adId: string, slot: string) {
+/** Collect all pending view/click counts from localStorage and send in one request. */
+async function flushAll() {
+  if (!ADS_TRACKING_ENABLED || isFlushing) return
+  isFlushing = true
+  try {
+    const entries = new Map<
+      string,
+      {
+        adId: string
+        slot: string
+        date: string
+        views: number
+        clicks: number
+      }
+    >()
+    for (let i = 0; i < localStorage.length; i++) {
+      const key = localStorage.key(i)
+      if (!key) continue
+      const m = /^ncol_([vc])_(.+)_(\d{4}-\d{2}-\d{2})$/.exec(key)
+      if (!m) continue
+      const [, type, adId, date] = m
+      const mapKey = `${adId}_${date}`
+      if (!entries.has(mapKey)) {
+        const slot = localStorage.getItem(`ncol_slot_${adId}`) ?? 'unknown'
+        entries.set(mapKey, { adId, slot, date, views: 0, clicks: 0 })
+      }
+      const entry = entries.get(mapKey)!
+      if (type === 'v') entry.views = getCount(key)
+      else entry.clicks = getCount(key)
+    }
+
+    const toSend = [...entries.values()].filter(e => e.views + e.clicks > 0)
+    if (toSend.length === 0) return
+
+    const ok = await sendBatchTrack(toSend)
+    if (ok) {
+      for (const { adId, date } of toSend) {
+        localStorage.removeItem(`ncol_v_${adId}_${date}`)
+        localStorage.removeItem(`ncol_c_${adId}_${date}`)
+      }
+    }
+  } finally {
+    isFlushing = false
+  }
+}
+
+// Register once per module load
+if (typeof window !== 'undefined' && ADS_TRACKING_ENABLED) {
+  void flushAll()
+  document.addEventListener('visibilitychange', () => void flushAll())
+  window.addEventListener('beforeunload', () => void flushAll())
+}
+
+function recordClick(adId: string) {
   if (!ADS_TRACKING_ENABLED) return
   const today = new Date().toISOString().slice(0, 10)
-  const key = `${adId}_${today}`
-  if (flushingKeys.has(key)) return
-  const kV = `ncol_v_${adId}_${today}`
   const kC = `ncol_c_${adId}_${today}`
-  const v = getCount(kV)
-  const c = getCount(kC)
-  if (v + c === 0) return
-  flushingKeys.add(key)
-  const ok = await sendTrack(adId, slot, today, v, c)
-  flushingKeys.delete(key)
-  if (ok) {
-    localStorage.removeItem(kV)
-    localStorage.removeItem(kC)
-  }
-}
-
-/** Flush any view/click counts from previous days left in localStorage.
- *  Called on mount and when the tab becomes visible — covers the mobile case
- *  where the browser tab is never closed and the user returns the next day. */
-async function flushStaleEntries() {
-  const today = new Date().toISOString().slice(0, 10)
-  const stale = new Map<string, { adId: string; date: string }>()
-  for (let i = 0; i < localStorage.length; i++) {
-    const key = localStorage.key(i)
-    if (!key) continue
-    const m = /^ncol_[vc]_(.+)_(\d{4}-\d{2}-\d{2})$/.exec(key)
-    if (!m || m[2] === today) continue
-    stale.set(`${m[1]}_${m[2]}`, { adId: m[1], date: m[2] })
-  }
-
-  for (const { adId, date } of stale.values()) {
-    const kV = `ncol_v_${adId}_${date}`
-    const kC = `ncol_c_${adId}_${date}`
-    const kS = `ncol_slot_${adId}`
-    const v = getCount(kV)
-    const c = getCount(kC)
-    const slot = localStorage.getItem(kS) ?? 'unknown'
-    if (v + c > 0) {
-      const ok = await sendTrack(adId, slot, date, v, c)
-      if (ok) {
-        localStorage.removeItem(kV)
-        localStorage.removeItem(kC)
-      }
-    } else {
-      localStorage.removeItem(kV)
-      localStorage.removeItem(kC)
-    }
-  }
-}
-
-// Run once per module load (covers hard refreshes and first visits)
-if (typeof window !== 'undefined' && ADS_TRACKING_ENABLED) {
-  void flushStaleEntries()
-  document.addEventListener('visibilitychange', () => {
-    if (document.visibilityState === 'visible') void flushStaleEntries()
-  })
+  localStorage.setItem(kC, String(getCount(kC) + 1))
+  void flushAll()
 }
 
 /**
@@ -283,32 +293,8 @@ function NcolAdSlotInner({ slot, className, priority }: NcolAdSlotProps) {
     return () => window.removeEventListener('resize', handleResize)
   }, [ad])
 
-  useEffect(() => {
-    if (!ad) return
-    function handleHide() {
-      if (document.visibilityState === 'hidden') {
-        void flush(ad!.id, slot)
-      }
-    }
-    function handleUnload() {
-      void flush(ad!.id, slot)
-    }
-    document.addEventListener('visibilitychange', handleHide)
-    window.addEventListener('beforeunload', handleUnload)
-    return () => {
-      document.removeEventListener('visibilitychange', handleHide)
-      window.removeEventListener('beforeunload', handleUnload)
-    }
-  }, [ad, slot])
-
   function handleClick() {
-    if (!ad) return
-    if (ADS_TRACKING_ENABLED) {
-      const today = new Date().toISOString().slice(0, 10)
-      const kC = `ncol_c_${ad.id}_${today}`
-      localStorage.setItem(kC, String(getCount(kC) + 1))
-      void flush(ad.id, slot)
-    }
+    if (ad) recordClick(ad.id)
   }
 
   if (!ad) {
@@ -423,34 +409,8 @@ function NcolAdSlotPopupInner() {
     return () => clearTimeout(t)
   }, [ads])
 
-  useEffect(() => {
-    if (!ad) return
-    // eslint-disable-next-line sonarjs/no-identical-functions
-    function handleHide() {
-      if (document.visibilityState === 'hidden') {
-        void flush(ad!.id, slot)
-      }
-    }
-    function handleUnload() {
-      void flush(ad!.id, slot)
-    }
-    document.addEventListener('visibilitychange', handleHide)
-    window.addEventListener('beforeunload', handleUnload)
-    return () => {
-      document.removeEventListener('visibilitychange', handleHide)
-      window.removeEventListener('beforeunload', handleUnload)
-    }
-  }, [ad])
-
-  // eslint-disable-next-line sonarjs/no-identical-functions
   function handleClick() {
-    if (!ad) return
-    if (ADS_TRACKING_ENABLED) {
-      const today = new Date().toISOString().slice(0, 10)
-      const kC = `ncol_c_${ad.id}_${today}`
-      localStorage.setItem(kC, String(getCount(kC) + 1))
-      void flush(ad.id, slot)
-    }
+    if (ad) recordClick(ad.id)
   }
 
   if (!ad || !visible) return null
@@ -641,34 +601,8 @@ function NcolAdSlotStickyBottomInner() {
     return () => window.removeEventListener('resize', handleResize)
   }, [ad])
 
-  useEffect(() => {
-    if (!ad) return
-    // eslint-disable-next-line sonarjs/no-identical-functions
-    function handleHide() {
-      if (document.visibilityState === 'hidden') {
-        void flush(ad!.id, slot)
-      }
-    }
-    function handleUnload() {
-      void flush(ad!.id, slot)
-    }
-    document.addEventListener('visibilitychange', handleHide)
-    window.addEventListener('beforeunload', handleUnload)
-    return () => {
-      document.removeEventListener('visibilitychange', handleHide)
-      window.removeEventListener('beforeunload', handleUnload)
-    }
-  }, [ad])
-
-  // eslint-disable-next-line sonarjs/no-identical-functions
   function handleClick() {
-    if (!ad) return
-    if (ADS_TRACKING_ENABLED) {
-      const today = new Date().toISOString().slice(0, 10)
-      const kC = `ncol_c_${ad.id}_${today}`
-      localStorage.setItem(kC, String(getCount(kC) + 1))
-      void flush(ad.id, slot)
-    }
+    if (ad) recordClick(ad.id)
   }
 
   if (!ad || closed) return null

--- a/src/components/NcolAdSlot/index.tsx
+++ b/src/components/NcolAdSlot/index.tsx
@@ -253,9 +253,9 @@ function NcolAdSlotInner({ slot, className, priority }: NcolAdSlotProps) {
   const mobile = useIsMobile()
 
   const reservedHeight =
-    slot === 'header' && RESERVE_HEADER_HEIGHT
-      ? getSlotHeight(slot, mobile)
-      : undefined
+    slot === 'header' && !RESERVE_HEADER_HEIGHT
+      ? undefined
+      : getSlotHeight(slot, mobile)
 
   useEffect(() => {
     if (!ad) return

--- a/src/components/PostHero/index.tsx
+++ b/src/components/PostHero/index.tsx
@@ -4,6 +4,7 @@ import { PostHome } from '@lib/types'
 import { DateTime } from '@components/DateTime'
 import { Excerpt } from '@components/Excerpt'
 import { PostHeroTitleLink } from './PostHeroTitleLink'
+import { NcolAdSlot } from '@components/NcolAdSlot'
 
 type PostHeroProps = {
   post: PostHome | null
@@ -15,40 +16,43 @@ const PostHero = ({ post }: PostHeroProps) => {
   const { featuredImage, uri, title, excerpt, date, categories } = post
 
   return (
-    <section className='mb-4'>
-      {featuredImage && title && (
-        <div className='relative z-1 -mx-6 -mb-12 h-48 w-auto sm:mx-0 sm:h-64 sm:w-full lg:h-72'>
-          <CoverImage
-            className='relative block h-48 w-full sm:h-60 md:h-60 lg:h-72'
-            priority={true}
-            uri={uri}
-            title={title}
-            coverImage={featuredImage?.node?.sourceUrl}
-            srcSet={featuredImage?.node?.srcSet}
-            size='lg'
-          />
-        </div>
-      )}
-      <div className='content border-primary relative z-2 -ml-6 w-auto border-t-4 bg-white px-5 py-4 sm:ml-0 sm:w-11/12 dark:bg-neutral-800 dark:hover:text-neutral-100'>
-        {categories && (
-          <PostCategories
-            slice={2}
-            className='text-primary mb-3 uppercase'
-            {...categories}
-          />
+    <>
+      <section className='mb-4'>
+        {featuredImage && title && (
+          <div className='relative z-1 -mx-6 -mb-12 h-48 w-auto sm:mx-0 sm:h-64 sm:w-full lg:h-72'>
+            <CoverImage
+              className='relative block h-48 w-full sm:h-60 md:h-60 lg:h-72'
+              priority={true}
+              uri={uri}
+              title={title}
+              coverImage={featuredImage?.node?.sourceUrl}
+              srcSet={featuredImage?.node?.srcSet}
+              size='lg'
+            />
+          </div>
         )}
-        {uri && (
-          <h1 className='mb-2 font-serif text-2xl leading-8 font-bold text-slate-900 lg:text-4xl lg:leading-11'>
-            <PostHeroTitleLink href={uri} title={title} />
-          </h1>
-        )}
-        <hr className='relative mt-4 mb-3 w-full text-slate-200 sm:w-48 md:w-80 dark:border-neutral-500' />
-        <div className='mb-4 font-sans text-xs md:mb-0'>
-          <Excerpt className='mb-2' text={excerpt} />
-          <DateTime dateString={date} />
+        <div className='content border-primary relative z-2 -ml-6 w-auto border-t-4 bg-white px-5 py-4 sm:ml-0 sm:w-11/12 dark:bg-neutral-800 dark:hover:text-neutral-100'>
+          {categories && (
+            <PostCategories
+              slice={2}
+              className='text-primary mb-3 uppercase'
+              {...categories}
+            />
+          )}
+          {uri && (
+            <h1 className='mb-2 font-serif text-2xl leading-8 font-bold text-slate-900 lg:text-4xl lg:leading-11'>
+              <PostHeroTitleLink href={uri} title={title} />
+            </h1>
+          )}
+          <hr className='relative mt-4 mb-3 w-full text-slate-200 sm:w-48 md:w-80 dark:border-neutral-500' />
+          <div className='mb-4 font-sans text-xs md:mb-0'>
+            <Excerpt className='mb-2' text={excerpt} />
+            <DateTime dateString={date} />
+          </div>
         </div>
-      </div>
-    </section>
+      </section>
+      <NcolAdSlot slot='article-top' className='my-4 flex justify-center' />
+    </>
   )
 }
 

--- a/src/components/TodayCategoryLabel/index.tsx
+++ b/src/components/TodayCategoryLabel/index.tsx
@@ -1,0 +1,26 @@
+import { TodayPost } from '@app/actions/getTodayYesterdayPosts'
+import { getPostCategoriesClasses } from '@components/PostCategories/styles'
+import { processCategories } from '@lib/utils/processCategories'
+import { CATEGORY_PATH } from '@lib/constants'
+import Link from 'next/link'
+
+const TodayCategoryLabel = ({
+  categories,
+  className
+}: {
+  categories: TodayPost['categories']
+  className?: string
+}) => {
+  const processed = processCategories(categories.edges, 1)
+  if (!processed.length) return null
+  const cat = processed[0]?.node
+  const classes = getPostCategoriesClasses(className)
+  if (!cat) return null
+  return (
+    <Link href={`${CATEGORY_PATH}/${cat.slug}`} className={classes}>
+      {cat.name}
+    </Link>
+  )
+}
+
+export { TodayCategoryLabel }

--- a/src/components/TodayHeroPost/__tests__/TodayHeroPost.test.tsx
+++ b/src/components/TodayHeroPost/__tests__/TodayHeroPost.test.tsx
@@ -68,12 +68,11 @@ describe('TodayHeroPost', () => {
     expect(container.querySelector('article')).toBeInTheDocument()
   })
 
-  test('both images use fetchPriority high and eager loading', () => {
+  test('images are not lazy loaded (priority rendering)', () => {
     const { getAllByRole } = render(<TodayHeroPost {...base} />)
     const imgs = getAllByRole('img')
     imgs.forEach(img => {
-      expect(img).toHaveAttribute('fetchpriority', 'high')
-      expect(img).toHaveAttribute('loading', 'eager')
+      expect(img).not.toHaveAttribute('loading', 'lazy')
     })
   })
 })

--- a/src/components/TodayHeroPost/__tests__/TodayHeroPost.test.tsx
+++ b/src/components/TodayHeroPost/__tests__/TodayHeroPost.test.tsx
@@ -1,0 +1,79 @@
+import { render, screen } from '@testing-library/react'
+import { TodayHeroPost } from '..'
+
+jest.mock('@components/HoverPrefetchLink', () => ({
+  HoverPrefetchLink: ({ children, href }: any) => <a href={href}>{children}</a>
+}))
+jest.mock('@components/DateTime', () => ({
+  DateTime: () => <time>date</time>
+}))
+jest.mock('@lib/utils/ga', () => ({ GAEvent: jest.fn() }))
+jest.mock('next/link', () => ({
+  __esModule: true,
+  default: ({ children, href }: any) => <a href={href}>{children}</a>
+}))
+
+const base = {
+  id: 'abc',
+  title: 'A long enough title for the hero post',
+  uri: '/post/abc',
+  date: '2026-04-23T10:00:00',
+  excerpt: '<p>Excerpt text</p>',
+  categories: {
+    edges: [
+      { node: { name: 'Nacionales', slug: 'nacionales', parentId: null } }
+    ]
+  },
+  featuredImage: {
+    node: {
+      sourceUrl: '/img.jpg',
+      srcSet: '/img.jpg 800w',
+      mediaDetails: { width: 800, height: 450 }
+    }
+  }
+}
+
+describe('TodayHeroPost', () => {
+  test('returns null when title is too short', () => {
+    const { container } = render(<TodayHeroPost {...base} title='short' />)
+    expect(container.firstChild).toBeNull()
+  })
+
+  test('renders smaller variant when image is narrow', () => {
+    const { container } = render(<TodayHeroPost {...base} />)
+    expect(container.querySelector('article')).toBeInTheDocument()
+    expect(screen.getByAltText(/a long enough/i)).toBeInTheDocument()
+    expect(screen.getByText(/nacionales/i)).toBeInTheDocument()
+  })
+
+  test('renders wide overlay variant when image width >= 1200', () => {
+    const wide = {
+      ...base,
+      featuredImage: {
+        node: {
+          ...base.featuredImage.node,
+          mediaDetails: { width: 1200, height: 600 }
+        }
+      }
+    }
+    render(<TodayHeroPost {...wide} />)
+    expect(screen.getByAltText(/a long enough/i)).toBeInTheDocument()
+    expect(screen.getByText(/nacionales/i)).toBeInTheDocument()
+  })
+
+  test('renders without featuredImage', () => {
+    const { container } = render(
+      <TodayHeroPost {...base} featuredImage={undefined} />
+    )
+    expect(container.querySelector('article')).toBeInTheDocument()
+  })
+
+  test('both images use fetchPriority high and eager loading', () => {
+    const { getAllByRole } = render(<TodayHeroPost {...base} />)
+    const imgs = getAllByRole('img')
+    imgs.forEach(img => {
+      expect(img).toHaveAttribute('fetchpriority', 'high')
+      expect(img).toHaveAttribute('loading', 'eager')
+    })
+  })
+})

--- a/src/components/TodayHeroPost/index.tsx
+++ b/src/components/TodayHeroPost/index.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import Image from 'next/image'
 import { TodayPost } from '@app/actions/getTodayYesterdayPosts'
 import { DateTime } from '@components/DateTime'
 import { HoverPrefetchLink } from '@components/HoverPrefetchLink'
@@ -29,10 +30,7 @@ const TodayHeroPost = ({
   if (isWide) {
     return (
       <article className='relative -mx-6 mb-4 overflow-hidden sm:-mx-7 sm:mx-0 sm:rounded-sm'>
-        <div
-          className='relative w-full overflow-hidden'
-          style={{ maxHeight: 500 }}
-        >
+        <div className='relative max-h-[500px] w-full overflow-hidden'>
           <HoverPrefetchLink
             href={uri}
             aria-label={limitedTitle}
@@ -43,14 +41,13 @@ const TodayHeroPost = ({
               })
             }
           >
-            {/* eslint-disable-next-line @next/next/no-img-element */}
-            <img
+            <Image
               src={featuredImage?.node.sourceUrl ?? ''}
-              srcSet={featuredImage?.node.srcSet}
               alt={limitedTitle}
+              width={featuredImage?.node?.mediaDetails?.width ?? 1200}
+              height={featuredImage?.node?.mediaDetails?.height ?? 675}
               className='w-full object-cover'
-              fetchPriority='high'
-              loading='eager'
+              priority
             />
           </HoverPrefetchLink>
           {customFields?.videodestacado && (
@@ -115,14 +112,13 @@ const TodayHeroPost = ({
               })
             }
           >
-            {/* eslint-disable-next-line @next/next/no-img-element */}
-            <img
+            <Image
               src={featuredImage.node.sourceUrl}
-              srcSet={featuredImage.node.srcSet}
               alt={limitedTitle}
+              width={featuredImage.node.mediaDetails?.width ?? 800}
+              height={featuredImage.node.mediaDetails?.height ?? 450}
               className='aspect-video w-full object-cover'
-              fetchPriority='high'
-              loading='eager'
+              priority
             />
           </HoverPrefetchLink>
           {customFields?.videodestacado && (

--- a/src/components/TodayHeroPost/index.tsx
+++ b/src/components/TodayHeroPost/index.tsx
@@ -1,0 +1,170 @@
+'use client'
+
+import { TodayPost } from '@app/actions/getTodayYesterdayPosts'
+import { DateTime } from '@components/DateTime'
+import { HoverPrefetchLink } from '@components/HoverPrefetchLink'
+import { TodayCategoryLabel } from '@components/TodayCategoryLabel'
+import { GAEvent } from '@lib/utils/ga'
+import { GA_EVENTS } from '@lib/constants'
+import { limitStringCharacters } from '@lib/utils/limitStringCharacters'
+
+const WIDE_IMAGE_THRESHOLD = 1200
+
+const TodayHeroPost = ({
+  title,
+  uri,
+  date,
+  excerpt,
+  featuredImage,
+  categories,
+  customFields
+}: TodayPost) => {
+  const limitedTitle = limitStringCharacters(title)
+  if (!limitedTitle || limitedTitle.length <= 10) return null
+
+  const imageWidth = featuredImage?.node?.mediaDetails?.width ?? 0
+  const isWide = imageWidth >= WIDE_IMAGE_THRESHOLD
+
+  // Wide image: full-width overlay, no horizontal padding (bleeds to container edges)
+  if (isWide) {
+    return (
+      <article className='relative -mx-6 mb-4 overflow-hidden sm:-mx-7 sm:mx-0 sm:rounded-sm'>
+        <div
+          className='relative w-full overflow-hidden'
+          style={{ maxHeight: 500 }}
+        >
+          <HoverPrefetchLink
+            href={uri}
+            aria-label={limitedTitle}
+            onClick={() =>
+              GAEvent({
+                category: GA_EVENTS.POST_LINK.SINGLE.CATEGORY,
+                label: 'TODAY_HERO_OVERLAY'
+              })
+            }
+          >
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            <img
+              src={featuredImage?.node.sourceUrl ?? ''}
+              srcSet={featuredImage?.node.srcSet}
+              alt={limitedTitle}
+              className='w-full object-cover'
+              fetchPriority='high'
+              loading='eager'
+            />
+          </HoverPrefetchLink>
+          {customFields?.videodestacado && (
+            <span className='bg-secondary pointer-events-none absolute top-2 right-2 z-20 rounded px-1.5 py-0.5 font-sans text-[10px] font-bold tracking-wide text-white uppercase shadow'>
+              + Video
+            </span>
+          )}
+          <div
+            className='pointer-events-none absolute inset-0'
+            style={{
+              background:
+                'linear-gradient(to top, rgba(0,0,0,0.92) 0%, rgba(0,0,0,0.6) 40%, transparent 70%)'
+            }}
+          />
+          <div className='absolute right-0 bottom-0 left-0 p-4 md:p-6'>
+            {categories && (
+              <TodayCategoryLabel
+                categories={categories}
+                className='mb-2 text-white/90'
+              />
+            )}
+            <h2 className='text-xl leading-snug font-bold text-white md:text-3xl'>
+              <HoverPrefetchLink
+                href={uri}
+                onClick={() =>
+                  GAEvent({
+                    category: GA_EVENTS.POST_LINK.SINGLE.CATEGORY,
+                    label: 'TODAY_HERO_OVERLAY'
+                  })
+                }
+              >
+                {limitedTitle}
+              </HoverPrefetchLink>
+            </h2>
+            {excerpt && (
+              <div
+                className='mt-2 line-clamp-2 hidden text-sm text-white sm:block'
+                dangerouslySetInnerHTML={{ __html: excerpt }}
+              />
+            )}
+            <div className='mt-2 text-sm text-white'>
+              <DateTime dateString={date} />
+            </div>
+          </div>
+        </div>
+      </article>
+    )
+  }
+
+  // Smaller image: image left, text right
+  return (
+    <article className='mt-6 mb-4 flex flex-col gap-5 sm:flex-row'>
+      {featuredImage && (
+        <div className='relative w-full shrink-0 overflow-hidden sm:w-[55%]'>
+          <HoverPrefetchLink
+            href={uri}
+            aria-label={limitedTitle}
+            onClick={() =>
+              GAEvent({
+                category: GA_EVENTS.POST_LINK.SINGLE.CATEGORY,
+                label: 'TODAY_HERO'
+              })
+            }
+          >
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            <img
+              src={featuredImage.node.sourceUrl}
+              srcSet={featuredImage.node.srcSet}
+              alt={limitedTitle}
+              className='aspect-video w-full object-cover'
+              fetchPriority='high'
+              loading='eager'
+            />
+          </HoverPrefetchLink>
+          {customFields?.videodestacado && (
+            <span className='bg-secondary pointer-events-none absolute top-1 right-1 z-20 rounded px-1.5 py-0.5 font-sans text-[10px] font-bold tracking-wide text-white uppercase shadow'>
+              + Video
+            </span>
+          )}
+        </div>
+      )}
+      <div className='flex flex-col justify-center'>
+        {categories && (
+          <TodayCategoryLabel
+            categories={categories}
+            className='text-primary mb-1 uppercase'
+          />
+        )}
+        <h2 className='text-xl leading-snug font-bold text-slate-900 md:text-2xl dark:text-white'>
+          <HoverPrefetchLink
+            href={uri}
+            aria-label={limitedTitle}
+            onClick={() =>
+              GAEvent({
+                category: GA_EVENTS.POST_LINK.SINGLE.CATEGORY,
+                label: 'TODAY_HERO'
+              })
+            }
+          >
+            {limitedTitle}
+          </HoverPrefetchLink>
+        </h2>
+        {excerpt && (
+          <div
+            className='mt-2 line-clamp-3 text-sm text-slate-600 dark:text-neutral-300'
+            dangerouslySetInnerHTML={{ __html: excerpt }}
+          />
+        )}
+        <div className='mt-2 text-sm text-slate-500 dark:text-neutral-400'>
+          <DateTime dateString={date} />
+        </div>
+      </div>
+    </article>
+  )
+}
+
+export { TodayHeroPost }

--- a/src/components/TodayNewsCard/__tests__/TodayNewsCard.test.tsx
+++ b/src/components/TodayNewsCard/__tests__/TodayNewsCard.test.tsx
@@ -1,0 +1,68 @@
+import { render, screen } from '@testing-library/react'
+import { TodayNewsCard } from '..'
+
+jest.mock('@components/HoverPrefetchLink', () => ({
+  HoverPrefetchLink: ({ children, href }: any) => <a href={href}>{children}</a>
+}))
+jest.mock('@components/DateTime', () => ({
+  DateTime: () => <time>date</time>
+}))
+jest.mock('@lib/utils/ga', () => ({ GAEvent: jest.fn() }))
+jest.mock('next/link', () => ({
+  __esModule: true,
+  default: ({ children, href }: any) => <a href={href}>{children}</a>
+}))
+
+const base = {
+  id: 'card-1',
+  title: 'A long enough card title to render',
+  uri: '/post/card-1',
+  date: '2026-04-23T10:00:00',
+  categories: {
+    edges: [{ node: { name: 'Deportes', slug: 'deportes', parentId: null } }]
+  },
+  featuredImage: {
+    node: {
+      sourceUrl: '/card.jpg',
+      srcSet: '/card.jpg 400w',
+      mediaDetails: { width: 400, height: 225 }
+    }
+  }
+}
+
+describe('TodayNewsCard', () => {
+  test('returns null when title is too short', () => {
+    const { container } = render(<TodayNewsCard {...base} title='short' />)
+    expect(container.firstChild).toBeNull()
+  })
+
+  test('renders image, category link, title and date', () => {
+    render(<TodayNewsCard {...base} />)
+    expect(screen.getByAltText(/a long enough card/i)).toBeInTheDocument()
+    expect(screen.getByText(/deportes/i)).toBeInTheDocument()
+    expect(screen.getByText(/a long enough card/i)).toBeInTheDocument()
+    expect(screen.getByText('date')).toBeInTheDocument()
+  })
+
+  test('category label links to category page', () => {
+    render(<TodayNewsCard {...base} />)
+    const link = screen.getByRole('link', { name: /deportes/i })
+    expect(link).toHaveAttribute('href', '/categoria/deportes')
+  })
+
+  test('renders without featuredImage', () => {
+    const { container } = render(
+      <TodayNewsCard {...base} featuredImage={undefined} />
+    )
+    expect(container.querySelector('article')).toBeInTheDocument()
+    expect(container.querySelector('img')).toBeNull()
+  })
+
+  test('image uses lazy loading', () => {
+    render(<TodayNewsCard {...base} />)
+    expect(screen.getByAltText(/a long enough card/i)).toHaveAttribute(
+      'loading',
+      'lazy'
+    )
+  })
+})

--- a/src/components/TodayNewsCard/index.tsx
+++ b/src/components/TodayNewsCard/index.tsx
@@ -25,6 +25,7 @@ const TodayNewsCard = ({
       <HoverPrefetchLink
         href={uri}
         aria-label={limitedTitle}
+        className='block'
         onClick={() =>
           GAEvent({
             category: GA_EVENTS.POST_LINK.SINGLE.CATEGORY,
@@ -33,12 +34,13 @@ const TodayNewsCard = ({
         }
       >
         {featuredImage && (
-          <div className='relative mb-3 aspect-video w-full overflow-hidden'>
+          <div className='relative mb-3 w-full overflow-hidden pb-[56.25%]'>
             <Image
               src={featuredImage.node.sourceUrl}
               alt={limitedTitle}
               fill
               className='object-cover'
+              sizes='(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 33vw'
             />
             {customFields?.videodestacado && (
               <span className='bg-secondary pointer-events-none absolute top-1 right-1 z-20 rounded px-1.5 py-0.5 font-sans text-[10px] font-bold tracking-wide text-white uppercase shadow'>

--- a/src/components/TodayNewsCard/index.tsx
+++ b/src/components/TodayNewsCard/index.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import Image from 'next/image'
 import { TodayPost } from '@app/actions/getTodayYesterdayPosts'
 import { DateTime } from '@components/DateTime'
 import { HoverPrefetchLink } from '@components/HoverPrefetchLink'
@@ -9,7 +10,6 @@ import { GA_EVENTS } from '@lib/constants'
 import { limitStringCharacters } from '@lib/utils/limitStringCharacters'
 
 const TodayNewsCard = ({
-  id,
   title,
   uri,
   date,
@@ -21,7 +21,7 @@ const TodayNewsCard = ({
   if (!limitedTitle || limitedTitle.length <= 10) return null
 
   return (
-    <article key={id} className='flex flex-col'>
+    <article className='flex flex-col'>
       <HoverPrefetchLink
         href={uri}
         aria-label={limitedTitle}
@@ -33,16 +33,12 @@ const TodayNewsCard = ({
         }
       >
         {featuredImage && (
-          <div
-            className='relative mb-3 w-full'
-            style={{ aspectRatio: '16/9', overflow: 'hidden' }}
-          >
-            {/* eslint-disable-next-line @next/next/no-img-element */}
-            <img
+          <div className='relative mb-3 aspect-video w-full overflow-hidden'>
+            <Image
               src={featuredImage.node.sourceUrl}
               alt={limitedTitle}
-              className='h-full w-full object-cover'
-              loading='lazy'
+              fill
+              className='object-cover'
             />
             {customFields?.videodestacado && (
               <span className='bg-secondary pointer-events-none absolute top-1 right-1 z-20 rounded px-1.5 py-0.5 font-sans text-[10px] font-bold tracking-wide text-white uppercase shadow'>

--- a/src/components/TodayNewsCard/index.tsx
+++ b/src/components/TodayNewsCard/index.tsx
@@ -1,0 +1,82 @@
+'use client'
+
+import { TodayPost } from '@app/actions/getTodayYesterdayPosts'
+import { DateTime } from '@components/DateTime'
+import { HoverPrefetchLink } from '@components/HoverPrefetchLink'
+import { TodayCategoryLabel } from '@components/TodayCategoryLabel'
+import { GAEvent } from '@lib/utils/ga'
+import { GA_EVENTS } from '@lib/constants'
+import { limitStringCharacters } from '@lib/utils/limitStringCharacters'
+
+const TodayNewsCard = ({
+  id,
+  title,
+  uri,
+  date,
+  featuredImage,
+  categories,
+  customFields
+}: TodayPost) => {
+  const limitedTitle = limitStringCharacters(title)
+  if (!limitedTitle || limitedTitle.length <= 10) return null
+
+  return (
+    <article key={id} className='flex flex-col'>
+      <HoverPrefetchLink
+        href={uri}
+        aria-label={limitedTitle}
+        onClick={() =>
+          GAEvent({
+            category: GA_EVENTS.POST_LINK.SINGLE.CATEGORY,
+            label: 'TODAY_NEWS_CARD'
+          })
+        }
+      >
+        {featuredImage && (
+          <div
+            className='relative mb-3 w-full'
+            style={{ aspectRatio: '16/9', overflow: 'hidden' }}
+          >
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            <img
+              src={featuredImage.node.sourceUrl}
+              alt={limitedTitle}
+              className='h-full w-full object-cover'
+              loading='lazy'
+            />
+            {customFields?.videodestacado && (
+              <span className='bg-secondary pointer-events-none absolute top-1 right-1 z-20 rounded px-1.5 py-0.5 font-sans text-[10px] font-bold tracking-wide text-white uppercase shadow'>
+                + Video
+              </span>
+            )}
+          </div>
+        )}
+      </HoverPrefetchLink>
+      {categories && (
+        <TodayCategoryLabel
+          categories={categories}
+          className='text-primary pt-1 pb-2 uppercase'
+        />
+      )}
+      <h3 className='text-base leading-snug font-semibold text-slate-900 dark:text-white'>
+        <HoverPrefetchLink
+          href={uri}
+          aria-label={limitedTitle}
+          onClick={() =>
+            GAEvent({
+              category: GA_EVENTS.POST_LINK.SINGLE.CATEGORY,
+              label: 'TODAY_NEWS_CARD'
+            })
+          }
+        >
+          {limitedTitle}
+        </HoverPrefetchLink>
+      </h3>
+      <div className='mt-2 text-xs text-slate-500 dark:text-neutral-400'>
+        <DateTime dateString={date} />
+      </div>
+    </article>
+  )
+}
+
+export { TodayNewsCard }

--- a/src/lib/hooks/data/useCategoryPosts.ts
+++ b/src/lib/hooks/data/useCategoryPosts.ts
@@ -7,6 +7,7 @@ import { query } from '@app/actions/getCategoryPagePosts/query'
 export function useCategoryPosts({
   slug,
   qty,
+  initialQty,
   offset,
   enabled
 }: PostsFetcherProps) {
@@ -16,7 +17,7 @@ export function useCategoryPosts({
     query,
     variables: {
       slug,
-      qty,
+      qty: initialQty ?? qty,
       offset: offset ?? 0,
       content: true
     },

--- a/src/lib/hooks/data/useCategoryPosts.ts
+++ b/src/lib/hooks/data/useCategoryPosts.ts
@@ -39,10 +39,15 @@ export function useCategoryPosts({
     await mutate(currentData => {
       if (!currentData || !newData) return currentData
 
+      const existingIds = new Set(currentData.posts.edges.map(e => e.node.id))
+      const dedupedNew = newData.posts.edges.filter(
+        e => !existingIds.has(e.node.id)
+      )
+
       return {
         posts: {
           ...currentData.posts,
-          edges: [...currentData.posts.edges, ...newData.posts.edges]
+          edges: [...currentData.posts.edges, ...dedupedNew]
         }
       }
     }, false)

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -277,6 +277,7 @@ export type MetadataProps = {
 export type PostsFetcherProps = {
   slug: string
   qty: number
+  initialQty?: number
   cursor?: string
   offset?: number
   enabled?: boolean

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -290,6 +290,7 @@ export type PostsFetcherReturn =
 export type LoaderProps = {
   slug: string
   qty: number
+  initialOffset?: number
   fetchMorePosts: (offset: number) => Promise<any>
 }
 


### PR DESCRIPTION
* feat: add today/yesterday featured posts module to main category pages

- Add `getTodayYesterdayPosts` server action that fetches up to 7 recent posts per category and filters to the last 3 days (Caracas time/UTC-4)
- Add `TodayHeroPost` component with adaptive layout: full-width overlay for wide images (≥1200px), image-left/text-right for smaller images; both use fetchPriority=high for fast LCP
- Add `TodayNewsCard` component for secondary posts grid (16:9 images, linked category label, title, date)
- Add `TodayYesterdayModule` with `TodayHeroSection` (full-width, outside sidebar) and `TodaySecondaryGrid` (2-3 col grid, rounded to multiples of 3, capped at 6 cards)
- Gate the module to MAIN_MENU slugs; exclude rendered posts from the client-side list below to prevent duplicates; always show 10 list posts
- Move post list thumbnail from right to left in CategoryArticle (list type)
- Add `excludeIds` and `initialOffset` props to CategoryPosts/LoaderCategoryPosts to keep pagination consistent after exclusions
- Add unit tests for all new components and the server action
- Add `@app/*` alias to Jest moduleNameMapper



* fix: add position relative to TodayNewsCard image container so video badge stays inside



* fix: show secondary posts in single column on mobile when count is 3

When there are exactly 3 secondary posts, use grid-cols-1 on mobile (sm:grid-cols-3 on wider screens) to avoid an orphaned card in a 2-col grid. 6 posts keeps grid-cols-2 on mobile and grid-cols-3 on md+.



* fix: hide hero excerpt on mobile, tighten post list title leading

- TodayHeroPost wide variant: excerpt hidden on mobile (sm:block)
- CategoryArticle list type: leading-snug on mobile, leading-7 on sm+



* refactor: extract shared TodayCategoryLabel, fix timezone bug, dedupe load-more posts

- Extract duplicated CategoryLabel into shared TodayCategoryLabel component
- Fix Caracas cutoff date using Intl.DateTimeFormat instead of host-offset math
- Rename date helper and add comment explaining 3-day window intent
- Add rounding invariant comment to getSecondaryPosts
- Remove meaningless key prop from single TodayHeroPost article roots
- Deduplicate appended posts in useCategoryPosts mutate to fix duplicate key warning



---------

## Summary
Provide a concise overview of the changes and their intent.

## Changes
- Bullet the key changes included in this PR.
- Mention any refactors, new components, or major logic updates.

## Type of change
- [ ] Feature
- [ ] Fix
- [ ] Refactor
- [ ] Chore (build, tooling, CI)
- [ ] Docs
- [ ] Tests

## Screenshots / Videos (optional)
Add visuals or clips that help reviewers understand the change.

## How to test
Step-by-step instructions for verifying the changes locally or in staging.
1. 
2. 
3. 

## Checklist
- [ ] Unit tests added/updated (if applicable)
- [ ] E2E tests updated (if applicable)
- [ ] Lint passes (`npm run lint`)
- [ ] Types compile (`npm run ts:compile`)
- [ ] Changes are scoped and minimal
- [ ] Documentation updated (if needed)

## Breaking changes
Describe any breaking changes and migration steps, or state “None”.

## Rollout & rollback
- Rollout plan: 
- Monitoring/alerts: 
- Rollback plan: 

## Related issues / links
Link to related issues, tickets, or docs.

## Notes
Anything else reviewers should know (trade-offs, follow-ups, risks).
