### PR TITLE
feat: SEO structured data and meta improvements

### DIFF
--- a/src/app/(category)/categoria/[...slug]/page.tsx
+++ b/src/app/(category)/categoria/[...slug]/page.tsx
@@ -17,10 +17,59 @@ import { getStaticSlugs } from '@lib/utils/getStaticSlugs'
 import { Suspense } from 'react'
 import { Loading } from '@components/LoadingCategory'
 import { NcolAdSlot } from '@components/NcolAdSlot'
+import { CMS_URL } from '@lib/constants'
 
 const SLUGS_WITH_TODAY_MODULE = new Set(
   MAIN_MENU.map(item => item.href.split('/').pop()).filter(Boolean)
 )
+
+// Slugs that benefit from "Hoy" in the title (news/location categories)
+const HOY_SLUGS = new Set([
+  'cabimas',
+  'maracaibo',
+  'ciudad-ojeda',
+  'sucesos',
+  'costa-oriental',
+  'zulia',
+  'nacionales',
+  'internacionales'
+])
+
+// Category-specific meta descriptions for key pages
+const CATEGORY_DESCRIPTIONS = new Map<string, string>([
+  [
+    'cabimas',
+    'Últimas noticias de Cabimas hoy. Sucesos, accidentes y actualidad de Cabimas, Costa Oriental del Lago de Maracaibo en Noticiascol.'
+  ],
+  [
+    'maracaibo',
+    'Últimas noticias de Maracaibo hoy. Sucesos, política y actualidad de Maracaibo, capital del estado Zulia en Noticiascol.'
+  ],
+  [
+    'ciudad-ojeda',
+    'Últimas noticias de Ciudad Ojeda hoy. Sucesos y actualidad de Ciudad Ojeda, Lagunillas, Costa Oriental del Lago de Maracaibo en Noticiascol.'
+  ],
+  [
+    'sucesos',
+    'Noticias de sucesos en Venezuela hoy. Accidentes, crímenes y actualidad policial del Zulia, Cabimas y Maracaibo en Noticiascol.'
+  ],
+  [
+    'costa-oriental',
+    'Noticias de la Costa Oriental del Lago hoy. Cabimas, Ciudad Ojeda y toda la actualidad del sur del lago de Maracaibo en Noticiascol.'
+  ],
+  [
+    'zulia',
+    'Últimas noticias del Zulia hoy. Sucesos, política y actualidad del estado Zulia, Venezuela en Noticiascol.'
+  ],
+  [
+    'nacionales',
+    'Últimas noticias nacionales de Venezuela hoy. Política, economía y actualidad del país en Noticiascol.'
+  ],
+  [
+    'internacionales',
+    'Noticias internacionales hoy. Actualidad del mundo, Latinoamérica y Venezuela en Noticiascol.'
+  ]
+])
 
 type Params = { slug: string[] }
 type SearchParams = { [key: string]: string | string[] | undefined }
@@ -32,10 +81,33 @@ export async function generateMetadata({
   searchParams: Promise<SearchParams>
 }) {
   const { slug } = await params
-  const lastSlug = Array.isArray(slug) ? slug[slug.length - 1] : slug
+  const slugArray = Array.isArray(slug) ? slug : [slug]
+  const lastSlug = slugArray[slugArray.length - 1]
+  const canonicalUrl = `${CMS_URL}/categoria/${slugArray.join('/')}/`
+
+  const name = categoryName(titleFromSlug(String(lastSlug)), true)
+  const title = HOY_SLUGS.has(lastSlug) ? `${name} Hoy` : name
+  const description =
+    CATEGORY_DESCRIPTIONS.get(lastSlug) ?? sharedOpenGraph.description
+
   return {
     ...sharedOpenGraph,
-    title: categoryName(titleFromSlug(String(lastSlug)), true)
+    title,
+    description,
+    alternates: {
+      canonical: canonicalUrl
+    },
+    openGraph: {
+      ...sharedOpenGraph.openGraph,
+      title,
+      description,
+      url: canonicalUrl
+    },
+    twitter: {
+      ...sharedOpenGraph.twitter,
+      title,
+      description
+    }
   }
 }
 
@@ -71,8 +143,31 @@ export default async function Page(props: {
   const excludeIds = todayEdges.slice(0, renderedCount).map(e => e.node.id)
   const shownCount = todayEdges.length
 
+  const breadcrumbJsonLd = {
+    '@context': 'https://schema.org',
+    '@type': 'BreadcrumbList',
+    itemListElement: [
+      {
+        '@type': 'ListItem',
+        position: 1,
+        name: 'Inicio',
+        item: CMS_URL
+      },
+      {
+        '@type': 'ListItem',
+        position: 2,
+        name: categoryName(titleFromSlug(slug), true),
+        item: `${CMS_URL}/categoria/${slug}/`
+      }
+    ]
+  }
+
   return (
     <>
+      <script
+        type='application/ld+json'
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbJsonLd) }}
+      />
       <PageTitle text={titleFromSlug(slug)} />
 
       {/* <div className='container mx-auto py-4'>

--- a/src/app/[posts]/[month]/[day]/[slug]/page.tsx
+++ b/src/app/[posts]/[month]/[day]/[slug]/page.tsx
@@ -7,7 +7,7 @@ import {
 } from '@app/actions/getPostAndMorePosts'
 import { Header } from '@components/Header'
 import { Content } from '@blocks/content/SinglePost'
-import { CMS_URL } from '@lib/constants'
+import { CMS_NAME, CMS_URL } from '@lib/constants'
 import { sharedOpenGraph } from '@lib/sharedOpenGraph'
 import { cleanExcerpt } from '@lib/utils/cleanExcerpt'
 import { MobileRankingLinks } from '@components/MobileRankingLinks'
@@ -30,19 +30,23 @@ export async function generateMetadata({
   const { posts, month, day, slug } = await params
   const slugUrl = `/${[posts, month, day, slug].filter(Boolean).join('/')}`
   const { post } = (await getMetadataPosts(slugUrl)) ?? {}
-  const { featuredImage, title, uri, excerpt, date } = post ?? {}
+  const { featuredImage, title, uri, excerpt, date, modified } = post ?? {}
   const description = cleanExcerpt(excerpt)
   const url = featuredImage?.node?.sourceUrl ?? ''
+  const canonicalUrl = uri ? `${CMS_URL}${uri}` : undefined
 
   return {
     ...sharedOpenGraph,
     title,
     description,
+    alternates: {
+      canonical: canonicalUrl
+    },
     openGraph: {
       ...sharedOpenGraph.openGraph,
       title,
       description,
-      url: `${CMS_URL}${uri}`,
+      url: canonicalUrl,
       images: [
         {
           url,
@@ -52,7 +56,8 @@ export async function generateMetadata({
         }
       ],
       type: 'article',
-      publishedTime: date ? new Date(date).toISOString() : ''
+      publishedTime: date ? new Date(date).toISOString() : '',
+      modifiedTime: modified ? new Date(modified).toISOString() : undefined
     },
     twitter: {
       ...sharedOpenGraph.twitter,
@@ -77,10 +82,53 @@ export default async function Page(props: {
   const day = params.day
   const buildSlug = `/${[posts, month, day, slug].filter(Boolean).join('/')}`
 
-  const initialData = await getSinglePost(buildSlug)
+  const [initialData, metaData] = await Promise.all([
+    getSinglePost(buildSlug),
+    getMetadataPosts(buildSlug)
+  ])
+
+  const { post } = metaData ?? {}
+  const newsArticleJsonLd = post
+    ? {
+        '@context': 'https://schema.org',
+        '@type': 'NewsArticle',
+        headline: post.title,
+        description: cleanExcerpt(post.excerpt),
+        datePublished: post.date
+          ? new Date(post.date).toISOString()
+          : undefined,
+        dateModified: post.modified
+          ? new Date(post.modified).toISOString()
+          : undefined,
+        url: `${CMS_URL}${post.uri}`,
+        image: post.featuredImage?.node?.sourceUrl
+          ? [post.featuredImage.node.sourceUrl]
+          : undefined,
+        isAccessibleForFree: true,
+        publisher: {
+          '@type': 'NewsMediaOrganization',
+          name: CMS_NAME,
+          url: CMS_URL,
+          logo: {
+            '@type': 'ImageObject',
+            url: 'https://noticiascol.com/media/logo-plain.png',
+            width: 200,
+            height: 60
+          }
+        }
+      }
+    : null
 
   return (
     <>
+      {newsArticleJsonLd && (
+        <script
+          type='application/ld+json'
+          dangerouslySetInnerHTML={{
+            __html: JSON.stringify(newsArticleJsonLd)
+          }}
+        />
+      )}
       <Header uri={buildSlug} />
       <MobileRankingLinks />
       <Content slug={buildSlug} rawSlug={slug} fallbackData={initialData} />

--- a/src/app/actions/getPostAndMorePosts/query.ts
+++ b/src/app/actions/getPostAndMorePosts/query.ts
@@ -98,6 +98,7 @@ export const queryMetaData = `
     post(id: $id, idType: $idType) {
       title
       date
+      modified
       excerpt
       uri
       featuredImage {

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -4,6 +4,8 @@ import { MAIN_MENU, CMS_URL, SERVICES_MENU } from '@lib/constants'
 // Priority sections to highlight for Google Sitelinks
 const PRIORITY_SECTIONS = [
   { url: '/categoria/sucesos/', name: 'Sucesos' },
+  { url: '/categoria/cabimas/', name: 'Cabimas' },
+  { url: '/categoria/maracaibo/', name: 'Maracaibo' },
   { url: '/categoria/costa-oriental/', name: 'Costa Oriental' },
   { url: '/categoria/zulia/', name: 'Zulia' },
   { url: '/categoria/ciudad-ojeda/', name: 'Ciudad Ojeda' },

--- a/src/components/TodayHeroPost/index.tsx
+++ b/src/components/TodayHeroPost/index.tsx
@@ -30,7 +30,7 @@ const TodayHeroPost = ({
   if (isWide) {
     return (
       <article className='relative -mx-6 mb-4 overflow-hidden sm:-mx-7 sm:mx-0 sm:rounded-sm'>
-        <div className='relative max-h-[500px] w-full overflow-hidden'>
+        <div className='relative max-h-[260px] w-full overflow-hidden sm:max-h-[500px]'>
           <HoverPrefetchLink
             href={uri}
             aria-label={limitedTitle}
@@ -46,7 +46,7 @@ const TodayHeroPost = ({
               alt={limitedTitle}
               width={featuredImage?.node?.mediaDetails?.width ?? 1200}
               height={featuredImage?.node?.mediaDetails?.height ?? 675}
-              className='w-full object-cover'
+              className='max-h-[260px] w-full object-cover sm:max-h-[500px]'
               priority
             />
           </HoverPrefetchLink>
@@ -101,7 +101,7 @@ const TodayHeroPost = ({
   return (
     <article className='mt-6 mb-4 flex flex-col gap-5 sm:flex-row'>
       {featuredImage && (
-        <div className='relative w-full shrink-0 overflow-hidden sm:w-[55%]'>
+        <div className='relative max-h-[260px] w-full shrink-0 overflow-hidden sm:max-h-[400px] sm:w-[55%]'>
           <HoverPrefetchLink
             href={uri}
             aria-label={limitedTitle}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -38,6 +38,7 @@ interface ContentType {
 export interface PostHeader extends CustomFields {
   title: string
   date?: string
+  modified?: string
   categories: Categories
   rawSlug?: string
   isLoading?: boolean


### PR DESCRIPTION
## Summary

- **NewsArticle JSON-LD** on single post pages — adds `headline`, `datePublished`, `dateModified`, `image`, and `publisher` for Google News / Discover rich results
- **Canonical URL** explicitly set on post pages via `alternates.canonical` (was previously inferred from `metadataBase`)
- **`dateModified`** added to both `NewsArticle` JSON-LD and OpenGraph `modifiedTime` tag — fetched via a new `modified` field in the `queryMetaData` GraphQL query and `PostHeader` type
- **Category pages**: BreadcrumbList JSON-LD, explicit canonical URLs, category-specific meta descriptions, and "Hoy" title suffix for key location/news slugs
- **Sitemap**: Cabimas and Maracaibo added to priority sections
- **TodayHeroPost**: responsive max-height on images (`max-h-[260px]` mobile / `max-h-[500px]` desktop)

## Test plan

- [ ] Validate post page JSON-LD with [Google's Rich Results Test](https://search.google.com/test/rich-results)
- [ ] Confirm canonical `<link>` appears correctly in post page `<head>`
- [ ] Check category pages render BreadcrumbList JSON-LD in source
- [ ] Verify hero image max-height on mobile and desktop viewports
- [ ] Run `npm run test:unit` — all passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)