### PR TITLE
feat: remove Salud from main menu

### DIFF
--- a/src/components/Footer/__tests__/__snapshots__/Footer.test.tsx.snap
+++ b/src/components/Footer/__tests__/__snapshots__/Footer.test.tsx.snap
@@ -300,16 +300,6 @@ exports[`Footer should match snapshots 1`] = `
                   Noticias de Entretenimiento
                 </a>
               </li>
-              <li
-                class="list-none"
-              >
-                <a
-                  class="link-footer relative inline-block pb-3 hover:text-white md:pb-2"
-                  href="/categoria/salud"
-                >
-                  Noticias de Salud
-                </a>
-              </li>
             </ul>
           </div>
           <div

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -110,8 +110,7 @@ export const MAIN_MENU: Link[] = [
   { name: 'Internacionales', href: `${CATEGORY_PATH}/internacionales` },
   { name: 'Deportes', href: `${CATEGORY_PATH}/deportes` },
   { name: 'Tendencias', href: `${CATEGORY_PATH}/tendencias` },
-  { name: 'Entretenimiento', href: `${CATEGORY_PATH}/entretenimiento` },
-  { name: 'Salud', href: `${CATEGORY_PATH}/salud` }
+  { name: 'Entretenimiento', href: `${CATEGORY_PATH}/entretenimiento` }
 ]
 
 export const FOOTER_LINKS: Link[] = MAIN_MENU

--- a/src/lib/utils/__tests__/categoryName.test.ts
+++ b/src/lib/utils/__tests__/categoryName.test.ts
@@ -13,7 +13,6 @@ describe('categoryName', () => {
     ${MAIN_MENU[4].name} | ${'Noticias de Deportes'}
     ${MAIN_MENU[5].name} | ${'Noticias de Tendencias'}
     ${MAIN_MENU[6].name} | ${'Noticias de Entretenimiento'}
-    ${MAIN_MENU[7].name} | ${'Noticias de Salud'}
   `(description, ({ name, expected }) => {
     expect(categoryName(name, true)).toBe(expected)
   })
@@ -27,7 +26,6 @@ describe('categoryName', () => {
     ${MENU[4].name} | ${'Noticias de Deportes'}
     ${MENU[5].name} | ${'Noticias de Tendencias'}
     ${MENU[6].name} | ${'Noticias de Entretenimiento'}
-    ${MENU[7].name} | ${'Noticias de Salud'}
   `(description, ({ name, expected }) => {
     expect(categoryName(name, true)).toBe(expected)
   })
@@ -62,7 +60,6 @@ describe('categoryName', () => {
     ${FOOTER_LINKS[4].name} | ${'Noticias de Deportes'}
     ${FOOTER_LINKS[5].name} | ${'Noticias de Tendencias'}
     ${FOOTER_LINKS[6].name} | ${'Noticias de Entretenimiento'}
-    ${FOOTER_LINKS[7].name} | ${'Noticias de Salud'}
   `(description, ({ name, expected }) => {
     expect(categoryName(name, true)).toBe(expected)
   })


### PR DESCRIPTION
## Summary
- Removes the "Salud" entry from `MAIN_MENU` in `src/lib/constants.ts`
- Updates the Footer snapshot test to reflect the removal
- Removes the `MAIN_MENU[7]`, `MENU[7]`, and `FOOTER_LINKS[7]` rows from `categoryName.test.ts`

## Test plan
- [x] All 50 Jest test suites pass
- [x] Footer snapshot updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)