### PR TITLE
Use --legacy-peer-deps in CI install

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,12 +16,12 @@ jobs:
   DeployApp:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v2
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/${{ secrets.APP_NAME }}-${{ secrets.APP_STAGE }}-github
           aws-region: us-east-1

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,6 +15,7 @@ permissions:
 jobs:
   DeployApp:
     runs-on: ubuntu-latest
+    environment: Production
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,5 +28,5 @@ jobs:
           aws-region: us-east-1
       - name: Deploy app
         run: |
-          npm ci
+          npm ci --legacy-peer-deps
           npx sst deploy --stage production

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/${{ secrets.APP_NAME }}-${{ secrets.APP_STAGE }}-github
+          role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/GitHub
           aws-region: us-east-1
       - name: Deploy app
         run: |

--- a/sst.config.ts
+++ b/sst.config.ts
@@ -12,6 +12,12 @@ export default $config({
   },
   async run() {
     new sst.aws.Nextjs('ncol-next', {
+      domain: process.env.DOMAIN_NAME && process.env.HOSTED_ZONE_ID ? {
+        name: `www.${process.env.DOMAIN_NAME}`,
+        redirects: [process.env.DOMAIN_NAME],
+        cert: process.env.CERT_ARN,
+        dns: sst.aws.dns({ zone: process.env.HOSTED_ZONE_ID })
+      } : undefined,
       imageOptimization: {
         memory: '512 MB',
         staticEtag: true
@@ -43,7 +49,7 @@ export default $config({
         MAILCHIMP_AUDIENCE_ID: process.env.MAILCHIMP_AUDIENCE_ID ?? '',
         TINYBIRD_TOKEN: process.env.TINYBIRD_TOKEN ?? '',
         TINYBIRD_URL: process.env.TINYBIRD_URL ?? '',
-        SITE_URL: process.env.DOMAIN_NAME ? `https://${process.env.DOMAIN_NAME}` : 'http://localhost:3000'
+        SITE_URL: process.env.DOMAIN_NAME ? `https://www.${process.env.DOMAIN_NAME}` : 'http://localhost:3000'
       }
     })
   }

--- a/sst.config.ts
+++ b/sst.config.ts
@@ -15,7 +15,7 @@ export default $config({
       domain: process.env.DOMAIN_NAME && process.env.HOSTED_ZONE_ID ? {
         name: `www.${process.env.DOMAIN_NAME}`,
         redirects: [process.env.DOMAIN_NAME],
-        cert: process.env.CERT_ARN,
+        ...(process.env.CERT_ARN ? { cert: process.env.CERT_ARN } : {}),
         dns: sst.aws.dns({ zone: process.env.HOSTED_ZONE_ID })
       } : undefined,
       imageOptimization: {


### PR DESCRIPTION
## Summary

`npm ci` fails because `@logtail/next@0.1.7` declares a peer dependency on Next.js `^12–15`, but the project runs Next.js 16. The CLAUDE.md already documents this conflict and prescribes `--legacy-peer-deps` as the workaround.

This matches how dependencies are installed in local dev.

https://claude.ai/code/session_011RThmoMC6qjfY2XAPQ79a2

---
_Generated by [Claude Code](https://claude.ai/code/session_011RThmoMC6qjfY2XAPQ79a2)_