### PR TITLE
Pass Turso and build-time env vars to deploy step

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,12 +16,12 @@ jobs:
   DeployApp:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v2
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/${{ secrets.APP_NAME }}-${{ secrets.APP_STAGE }}-github
           aws-region: us-east-1

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,6 +15,7 @@ permissions:
 jobs:
   DeployApp:
     runs-on: ubuntu-latest
+    environment: Production
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,6 +27,13 @@ jobs:
           role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/GitHub
           aws-region: us-east-1
       - name: Deploy app
+        env:
+          TURSO_DB_URL: ${{ secrets.TURSO_DB_URL }}
+          TURSO_AUTH_TOKEN: ${{ secrets.TURSO_AUTH_TOKEN }}
+          TURSO_DOLAR_DB_URL: ${{ secrets.TURSO_DOLAR_DB_URL }}
+          TURSO_DOLAR_AUTH_TOKEN: ${{ secrets.TURSO_DOLAR_AUTH_TOKEN }}
+          WORDPRESS_API_URL: ${{ secrets.WORDPRESS_API_URL }}
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
         run: |
           npm ci --legacy-peer-deps
           npx sst deploy --stage production

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,5 +28,5 @@ jobs:
           aws-region: us-east-1
       - name: Deploy app
         run: |
-          npm ci
+          npm ci --legacy-peer-deps
           npx sst deploy --stage production

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/${{ secrets.APP_NAME }}-${{ secrets.APP_STAGE }}-github
+          role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/GitHub
           aws-region: us-east-1
       - name: Deploy app
         run: |

--- a/sst.config.ts
+++ b/sst.config.ts
@@ -12,6 +12,12 @@ export default $config({
   },
   async run() {
     new sst.aws.Nextjs('ncol-next', {
+      domain: process.env.DOMAIN_NAME && process.env.HOSTED_ZONE_ID ? {
+        name: `www.${process.env.DOMAIN_NAME}`,
+        redirects: [process.env.DOMAIN_NAME],
+        cert: process.env.CERT_ARN,
+        dns: sst.aws.dns({ zone: process.env.HOSTED_ZONE_ID })
+      } : undefined,
       imageOptimization: {
         memory: '512 MB',
         staticEtag: true
@@ -43,7 +49,7 @@ export default $config({
         MAILCHIMP_AUDIENCE_ID: process.env.MAILCHIMP_AUDIENCE_ID ?? '',
         TINYBIRD_TOKEN: process.env.TINYBIRD_TOKEN ?? '',
         TINYBIRD_URL: process.env.TINYBIRD_URL ?? '',
-        SITE_URL: process.env.DOMAIN_NAME ? `https://${process.env.DOMAIN_NAME}` : 'http://localhost:3000'
+        SITE_URL: process.env.DOMAIN_NAME ? `https://www.${process.env.DOMAIN_NAME}` : 'http://localhost:3000'
       }
     })
   }

--- a/sst.config.ts
+++ b/sst.config.ts
@@ -15,7 +15,7 @@ export default $config({
       domain: process.env.DOMAIN_NAME && process.env.HOSTED_ZONE_ID ? {
         name: `www.${process.env.DOMAIN_NAME}`,
         redirects: [process.env.DOMAIN_NAME],
-        cert: process.env.CERT_ARN,
+        ...(process.env.CERT_ARN ? { cert: process.env.CERT_ARN } : {}),
         dns: sst.aws.dns({ zone: process.env.HOSTED_ZONE_ID })
       } : undefined,
       imageOptimization: {


### PR DESCRIPTION
## Summary

`next build` crashes collecting page data for `/api/dolar` because `TURSO_DB_URL` is empty. GitHub environment secrets must be explicitly mapped via `env:` in the step — they don't automatically become shell env vars.

## Required secrets to add before merging

Go to **GitHub → repo Settings → Environments → Production → Add secret** and add:

| Secret | Description |
|--------|-------------|
| `TURSO_DB_URL` | Turso views DB URL (e.g. `libsql://...turso.io`) |
| `TURSO_AUTH_TOKEN` | Turso views DB auth token |
| `TURSO_DOLAR_DB_URL` | Turso dolar DB URL |
| `TURSO_DOLAR_AUTH_TOKEN` | Turso dolar DB auth token |
| `WORDPRESS_API_URL` | WordPress GraphQL endpoint |
| `SENTRY_AUTH_TOKEN` | Sentry source map upload token |

https://claude.ai/code/session_011RThmoMC6qjfY2XAPQ79a2

---
_Generated by [Claude Code](https://claude.ai/code/session_011RThmoMC6qjfY2XAPQ79a2)_