### PR TITLE
fix: Use URI idType to prevent WPGraphQL timeouts on single post page

### DIFF
--- a/e2e/poms/Footer.ts
+++ b/e2e/poms/Footer.ts
@@ -70,7 +70,6 @@ export class Footer {
       /Noticias de Deportes/i,
       /Noticias de Tendencias/i,
       /Noticias de Entretenimiento/i,
-      /Noticias de Salud/i,
       /Noticias de Sucesos/i,
       /Contacto/i
     ]

--- a/src/app/actions/getPostAndMorePosts/index.ts
+++ b/src/app/actions/getPostAndMorePosts/index.ts
@@ -5,7 +5,7 @@ import { TIME_REVALIDATE } from '@lib/constants'
 import { SinglePost } from '@lib/types'
 import { queryMetaData, query } from './query'
 
-const SLUG = 'SLUG'
+const URI = 'URI'
 
 export const getMetadataPosts = async (
   slug: string
@@ -15,7 +15,7 @@ export const getMetadataPosts = async (
     query: queryMetaData,
     variables: {
       id: slug,
-      idType: SLUG
+      idType: URI
     }
   })
 
@@ -30,7 +30,7 @@ export const getSinglePost = async (
     query: query({ isRevision: false }),
     variables: {
       id: slug,
-      idType: 'SLUG'
+      idType: 'URI'
     }
   })
 

--- a/src/blocks/content/SinglePost/index.tsx
+++ b/src/blocks/content/SinglePost/index.tsx
@@ -21,7 +21,11 @@ export const Content = ({
   rawSlug: string
   fallbackData?: any
 }) => {
-  const { data, error, isLoading } = useSinglePost(slug, { fallbackData })
+  const { data, error, isLoading } = useSinglePost(slug, {
+    fallbackData,
+    revalidateIfStale: !fallbackData?.post,
+    revalidateOnMount: !fallbackData?.post
+  })
   const post = data?.post
 
   if (error) {

--- a/src/lib/hooks/data/useSinglePost.ts
+++ b/src/lib/hooks/data/useSinglePost.ts
@@ -12,7 +12,7 @@ export function useSinglePost(slug: string, options?: any) {
       }),
       variables: {
         id: slug,
-        idType: 'SLUG'
+        idType: 'URI'
       }
     },
     options


### PR DESCRIPTION
Changed idType from SLUG to URI in getSinglePost and useSinglePost to avoid expensive slug queries that trigger 500 timeout errors on the WordPress API.