### PR TITLE
fix: prevent failed-to-pipe-response on WordPress fetch timeout

### DIFF
--- a/src/app/articles-sitemap/[page]/route.ts
+++ b/src/app/articles-sitemap/[page]/route.ts
@@ -50,7 +50,8 @@ export async function GET(
   try {
     const res = await fetch(url, {
       headers: getAuthHeader(),
-      next: { revalidate: 3600 }
+      cache: 'no-store',
+      signal: AbortSignal.timeout(8000)
     })
 
     if (res.status === 400) {

--- a/src/app/articles-sitemap/route.ts
+++ b/src/app/articles-sitemap/route.ts
@@ -36,7 +36,8 @@ export async function GET() {
   try {
     const res = await fetch(url, {
       headers: getAuthHeader(),
-      next: { revalidate: 3600 }
+      cache: 'no-store',
+      signal: AbortSignal.timeout(8000)
     })
 
     if (!res.ok) {


### PR DESCRIPTION
## Root cause

Both `articles-sitemap` routes had **double-caching**:

1. **Route-segment ISR** — `export const revalidate = 3600` caches the full response for 1 hour
2. **Fetch-level cache** — `next: { revalidate: 3600 }` on the inner `fetch()` to WordPress also caches

The fetch-level cache causes Next.js to run a **background revalidation** of that cache after the stale response headers have already been sent to the client. When that background fetch to `admin.noticiascol.com:443` times out (`ConnectTimeoutError` after 10 s), the error escapes the `try/catch` block and surfaces as:

```
TypeError: fetch failed
Error: failed to pipe response
ConnectTimeoutError: Connect Timeout Error (attempted address: admin.noticiascol.com:443, timeout: 10000ms)
```

## Fix

- Replace `next: { revalidate: 3600 }` with `cache: 'no-store'` in the inner `fetch()` calls — eliminates fetch-level background revalidation entirely
- Route-segment ISR (`export const revalidate = 3600`) continues to handle caching at the full-response level, unchanged
- Add `signal: AbortSignal.timeout(8000)` to fail fast (8 s) instead of waiting for the default 10 s undici connection timeout

## Files changed

- `src/app/articles-sitemap/route.ts`
- `src/app/articles-sitemap/[page]/route.ts`

## Test plan

- [ ] Deploy to staging and confirm `Error: failed to pipe response` no longer appears in logs when WordPress is slow/unreachable
- [ ] Verify `/articles-sitemap` and `/articles-sitemap/[page]` still return valid XML sitemaps when WordPress is up
- [ ] Confirm ISR caching still works (responses are cached for 1 hour at the route level)

---
_Generated by [Claude Code](https://claude.ai/code/session_01ERdbtandbnA8sdSgrntpEM)_