### PR TITLE
fix(sst): reduce server Lambda timeout to 10s

### DIFF
--- a/sst.config.ts
+++ b/sst.config.ts
@@ -50,6 +50,7 @@ export default $config({
       },
       transform: {
         server: {
+          timeout: '10 seconds',
           loggingConfig: {
             logFormat: 'JSON',
             systemLogLevel: 'WARN',


### PR DESCRIPTION
## Summary
- Reduces Next.js server Lambda timeout from 20s to 10s in `sst.config.ts`

## Why
During EC2 CPU saturation events (Googlebot crawling 84K pending pages, traffic spikes), WordPress becomes slow and Lambda functions hang waiting for GraphQL responses. With a 20s timeout, each stuck invocation accumulates 20GB-seconds of cost. At 10s, worst-case cost per invocation is halved.

**Observed impact:** May 31 spike cost $28.22 — 208K invocations averaging 8s each. June 9 cost $3.26 with similar pattern at 07-08 UTC.

## Test plan
- [ ] Deploy to staging and verify server function timeout is 10s in AWS Lambda console
- [ ] Confirm pages still load correctly (normal responses are 200-400ms, well under 10s)

🤖 Generated with [Claude Code](https://claude.com/claude-code)