### PR TITLE
fix(header): make "Desde 2012" text white on primary header

### DIFF
--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -41,7 +41,7 @@ const Header = ({
       <SideNav />
       <header className={headerClasses}>
         <Container className='flex items-center'>
-          <div className='col'>
+          <div className='col relative'>
             <span className='md:hidden'>
               <Logo {...logoMobile} location='header' />
             </span>
@@ -49,6 +49,11 @@ const Header = ({
               <Logo {...logoDesktop} location='header' />
             </span>
             {title && <span className='sr-only'>{title}</span>}
+            <p
+              className={`absolute top-full left-0 font-sans text-[10px] tracking-widest uppercase ${isHeaderPrimary ? 'text-white/70' : 'text-neutral-500 dark:text-neutral-400'}`}
+            >
+              Desde 2012
+            </p>
           </div>
           {isHeaderHome && (
             <div className='col hidden pt-2 pl-4 sm:block md:pl-8'>


### PR DESCRIPTION
## Summary
- Fixes invisible "Desde 2012" text on category pages where the header uses `bg-primary` (blue background)

## Root cause
The `<p>` element had `text-neutral-500` hardcoded with no condition. All other header elements (buttons, icons, search) already conditionally use `text-white` when `isHeaderPrimary` is true — this element was missed.

## Fix
Applies `text-white/70` when `isHeaderPrimary`, otherwise keeps `text-neutral-500 dark:text-neutral-400` for the default white/dark header.

## Test plan
- [x] Verified visually on `localhost:3000/categoria/zulia/` — text is now visible
- [x] Header tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)