### PR TITLE
perf(sst): cap Lambda server concurrency at 50

### DIFF
--- a/sst.config.ts
+++ b/sst.config.ts
@@ -51,6 +51,7 @@ export default $config({
       transform: {
         server: {
           timeout: '10 seconds',
+          reservedConcurrentExecutions: 50,
           loggingConfig: {
             logFormat: 'JSON',
             systemLogLevel: 'WARN',


### PR DESCRIPTION
## Summary

- Sets `reservedConcurrentExecutions: 50` on the Next.js server Lambda
- Prevents EC2 CPU saturation during Googlebot crawl spikes (84K pages pending indexation)
- Without this limit, concurrent Lambda invocations pile up waiting for WordPress GraphQL, burning GB-seconds — root cause of the $28 Lambda bill on May 31
- Fast 429s on overflow are cheaper than 10s timeouts × unbounded concurrency

## Test plan

- [ ] Deploy to staging and verify pages still load normally
- [ ] Check Lambda concurrency metric in CloudWatch stays ≤ 50 during normal traffic
- [ ] Monitor Lambda cost over next 24h for reduction

🤖 Generated with [Claude Code](https://claude.com/claude-code)