### PR TITLE
perf(images): enable WebP/AVIF optimization to reduce CloudFront transfer

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -51,7 +51,6 @@ const nextConfig = {
   },
   reactStrictMode: false,
   images: {
-    unoptimized: true,
     formats: ['image/avif', 'image/webp'],
     minimumCacheTTL: 31536000, // 1 year in seconds
     remotePatterns: [


### PR DESCRIPTION
## Summary

- Removes `unoptimized: true` from `next.config.mjs`
- Enables the SST image optimizer Lambda already deployed (512MB memory)
- Images will be served as WebP/AVIF instead of raw JPEGs
- Results cached in CloudFront for 1 year — one-time Lambda cost per image

## Expected impact

- ~30% reduction in image payload size
- Lower CloudFront data transfer costs (especially South American edge which charges 3x US rates)
- Tiny one-time Lambda cost (~$0.03) to optimize all unique images on first request

## Test plan

- [ ] Deploy to staging and verify images load correctly
- [ ] Check a page and confirm `/_next/image` URLs are being used
- [ ] Verify image format is WebP in browser DevTools Network tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)