### PR TITLE
fix(images): remove avif from optimizer formats to fix Lambda crash

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -51,7 +51,7 @@ const nextConfig = {
   },
   reactStrictMode: false,
   images: {
-    formats: ['image/avif', 'image/webp'],
+    formats: ['image/webp'],
     minimumCacheTTL: 31536000, // 1 year in seconds
     remotePatterns: [
       {


### PR DESCRIPTION
The Lambda's sharp binary cannot encode AVIF, causing TypeError: a is not a function whenever the image optimizer is asked for an AVIF variant. WebP alone is sufficient and works correctly in the Lambda environment.

## Summary
Provide a concise overview of the changes and their intent.

## Changes
- Bullet the key changes included in this PR.
- Mention any refactors, new components, or major logic updates.

## Type of change
- [ ] Feature
- [ ] Fix
- [ ] Refactor
- [ ] Chore (build, tooling, CI)
- [ ] Docs
- [ ] Tests

## Screenshots / Videos (optional)
Add visuals or clips that help reviewers understand the change.

## How to test
Step-by-step instructions for verifying the changes locally or in staging.
1. 
2. 
3. 

## Checklist
- [ ] Unit tests added/updated (if applicable)
- [ ] E2E tests updated (if applicable)
- [ ] Lint passes (`npm run lint`)
- [ ] Types compile (`npm run ts:compile`)
- [ ] Changes are scoped and minimal
- [ ] Documentation updated (if needed)

## Breaking changes
Describe any breaking changes and migration steps, or state “None”.

## Rollout & rollback
- Rollout plan: 
- Monitoring/alerts: 
- Rollback plan: 

## Related issues / links
Link to related issues, tickets, or docs.

## Notes
Anything else reviewers should know (trade-offs, follow-ups, risks).
