### PR TITLE
fix(images): hide featured images on posts older than S3 lifecycle limit

### DIFF
--- a/src/components/PostContent/index.tsx
+++ b/src/components/PostContent/index.tsx
@@ -14,6 +14,8 @@ import ContextStateData from '@lib/context/StateContext'
 import { useUserCategories } from '@lib/hooks/useUserCategories'
 import dynamic from 'next/dynamic'
 import { NcolAdSlot } from '@components/NcolAdSlot'
+import { S3_IMAGE_MAX_AGE_DAYS } from '@lib/constants'
+import { isPostPublishedWithinDays } from '@lib/utils/isPostPublishedWithinDays'
 
 const VideoPlayer = dynamic(() =>
   import('@components/VideoPlayer').then(mod => mod.VideoPlayer)
@@ -111,7 +113,8 @@ export const PostContent = ({
         {hasVideo ? (
           <VideoPlayer url={customFields.videodestacado!} />
         ) : (
-          featuredImage && (
+          featuredImage &&
+          isPostPublishedWithinDays(date, S3_IMAGE_MAX_AGE_DAYS) && (
             <div className='relative mb-4 w-full lg:max-h-[500px]'>
               <CoverImage
                 className='relative mb-4 block w-full overflow-hidden rounded-sm lg:max-h-[500px]'

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -165,6 +165,9 @@ export const TIME_REVALIDATE = {
   WEEK: 604800
 }
 
+// S3 lifecycle rule deletes images after 1095 days — hide featured images on older posts
+export const S3_IMAGE_MAX_AGE_DAYS = 1095
+
 // WORDPRESS IMAGE SIZES
 export const IMAGE_SIZES = {
   LARGE: 'LARGE',


### PR DESCRIPTION
## Summary

- S3 lifecycle rule on `ncol-images` bucket deletes images after **1095 days (3 years)**
- Posts older than that return 403 from the image optimizer Lambda for missing images, generating Lambda errors and unnecessary CloudFront/Lambda invocations
- Added `S3_IMAGE_MAX_AGE_DAYS = 1095` constant and guard in `PostContent` so `CoverImage` is not rendered (and no `/_next/image` request is made) for posts outside the retention window

## Changes

- `src/lib/constants.ts` — new `S3_IMAGE_MAX_AGE_DAYS` constant tied to the S3 lifecycle rule
- `src/components/PostContent/index.tsx` — `CoverImage` gated with `isPostPublishedWithinDays(date, S3_IMAGE_MAX_AGE_DAYS)`

## Test plan

- [ ] All 334 unit tests pass
- [ ] Open a post older than 3 years — no featured image renders, no 403 in Lambda logs
- [ ] Open a post newer than 3 years — featured image renders normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)