### PR TITLE
feat(mundial): show penalty shootout scores on match cards

### DIFF
--- a/src/components/mundial/MatchCard.tsx
+++ b/src/components/mundial/MatchCard.tsx
@@ -83,15 +83,25 @@ export const MatchCard = ({ partido }: { partido: Partido }) => {
         {/* Score / vs */}
         <div className='flex w-24 shrink-0 flex-col items-center justify-center'>
           {hasScore ? (
-            <div className='flex items-center gap-1'>
-              <span className='min-w-[1.5rem] text-center text-2xl font-black text-white tabular-nums'>
-                {partido.goles_local ?? '–'}
-              </span>
-              <span className='text-gray-300'>—</span>
-              <span className='min-w-[1.5rem] text-center text-2xl font-black text-white tabular-nums'>
-                {partido.goles_visita ?? '–'}
-              </span>
-            </div>
+            <>
+              <div className='flex items-center gap-1'>
+                <span className='min-w-[1.5rem] text-center text-2xl font-black text-white tabular-nums'>
+                  {partido.goles_local ?? '–'}
+                </span>
+                <span className='text-gray-300'>—</span>
+                <span className='min-w-[1.5rem] text-center text-2xl font-black text-white tabular-nums'>
+                  {partido.goles_visita ?? '–'}
+                </span>
+              </div>
+              {partido.penales_local != null &&
+                partido.penales_visita != null && (
+                  <div className='flex items-center gap-1 text-[11px] text-yellow-300 tabular-nums'>
+                    <span>({partido.penales_local})</span>
+                    <span className='text-gray-400'>—</span>
+                    <span>({partido.penales_visita})</span>
+                  </div>
+                )}
+            </>
           ) : (
             <span className='text-base font-bold text-gray-300'>vs</span>
           )}
@@ -139,11 +149,21 @@ export const MatchCardCompact = ({ partido }: { partido: Partido }) => {
       {/* Center: score or time + status + group */}
       <div className='flex w-28 shrink-0 flex-col items-center'>
         {hasScore ? (
-          <div className='flex items-center gap-1 text-sm font-black text-white tabular-nums'>
-            <span>{partido.goles_local ?? '–'}</span>
-            <span className='text-gray-400'>—</span>
-            <span>{partido.goles_visita ?? '–'}</span>
-          </div>
+          <>
+            <div className='flex items-center gap-1 text-sm font-black text-white tabular-nums'>
+              <span>{partido.goles_local ?? '–'}</span>
+              <span className='text-gray-400'>—</span>
+              <span>{partido.goles_visita ?? '–'}</span>
+            </div>
+            {partido.penales_local != null &&
+              partido.penales_visita != null && (
+                <div className='flex items-center gap-1 text-[10px] text-yellow-300 tabular-nums'>
+                  <span>({partido.penales_local})</span>
+                  <span className='text-gray-400'>—</span>
+                  <span>({partido.penales_visita})</span>
+                </div>
+              )}
+          </>
         ) : (
           <span className='text-xs font-bold text-gray-100'>
             {formatMatchTime(partido.fecha_partido)}

--- a/src/components/mundial/MatchesSection.tsx
+++ b/src/components/mundial/MatchesSection.tsx
@@ -109,7 +109,7 @@ export const MatchesSection = () => {
     const { data } = await supabase
       .from('partidos')
       .select(
-        'id,equipo_local,equipo_visita,escudo_local,escudo_visita,fecha_partido,goles_local,goles_visita,estado,minuto,grupo'
+        'id,equipo_local,equipo_visita,escudo_local,escudo_visita,fecha_partido,goles_local,goles_visita,penales_local,penales_visita,estado,minuto,grupo'
       )
       .order('fecha_partido', { ascending: true })
     if (data) setPartidos(data)

--- a/src/components/mundial/types.ts
+++ b/src/components/mundial/types.ts
@@ -18,6 +18,8 @@ export interface Partido {
   fecha_partido: string
   goles_local: number | null
   goles_visita: number | null
+  penales_local: number | null
+  penales_visita: number | null
   estado: EstadoPartido
   minuto: string | null
   grupo: string | null


### PR DESCRIPTION
## Summary

- Adds `penales_local` and `penales_visita` fields to the `Partido` type and Supabase SELECT query
- Renders penalty scores in parentheses below the goals score on both the full `MatchCard` (Hoy tab) and compact `MatchCardCompact` (Resultados tab)
- Penalty row is only shown when both `penales_local` and `penales_visita` are non-null (e.g. `(4) — (3)`)

**Display example for a penalty match:**
```
2 — 2
(4) — (3)
```

## Note

Requires `penales_local` and `penales_visita` columns to exist on the Supabase `partidos` table (`integer`, nullable).

## Test plan

- [x] Unit tests pass (334 tests, 0 failures)
- [x] ESLint passes with zero warnings
- [ ] Verify in `/categoria/mundial-2026` Resultados tab that penalty matches show the `(n) — (n)` row and non-penalty matches do not

🤖 Generated with [Claude Code](https://claude.com/claude-code)